### PR TITLE
Add variant of foldp whose initial value comes from the source signal

### DIFF
--- a/core-js/Prelude.js
+++ b/core-js/Prelude.js
@@ -94,6 +94,7 @@ var Prelude = function() {
 	    lift3 : Signal.lift3,
 	    lift4 : Signal.lift4,
 	    foldp : Signal.foldp,
+	    foldp1 : Signal.foldp1,
 	    constant : Signal.constant,
 	    count : Signal.count,
 	    keepIf : Signal.keepIf,

--- a/core-js/runtime/Dispatcher.js
+++ b/core-js/runtime/Dispatcher.js
@@ -50,9 +50,9 @@ var Elm = function() {
 	    args[i].kids.push(this);
 	}
     };
-    var fold = function(func,base,input) {
+    var fold = function(func,base,baseIsFunc,input) {
 	this.id = Guid.guid();
-	this.value = base;
+	this.value = baseIsFunc ? base(input.value) : base;
 	this.kids = [];
 	this.recv = function(timestep, changed, parentID) {
 	    if (changed) { this.value = func(input.value)(this.value); }
@@ -113,7 +113,8 @@ var Elm = function() {
 
     return {Input: function(x) {return new input(x);},
 	    Lift:  function(f,xs){return new lift(f,xs);},
-	    Fold:  function(f,b,x){return new fold(f,b,x);},
+	    Fold:  function(f,b,x){return new fold(f,b,false,x);},
+	    Fold1: function(f,b,x){return new fold(f,b,true,x);},
 	    keepIf : function(pred) { return function(base) { return function(sig) {
 		    return new dropIf(function(x) { return !pred(x)},base,sig); }; }; },
 	    dropIf : function(pred) { return function(base) { return function(sig) {

--- a/core-js/runtime/Signal.js
+++ b/core-js/runtime/Signal.js
@@ -347,6 +347,8 @@ var Signal = function() {
 			  return Elm.Lift(f, [e1,e2,e3,e4]); }; }; }; }; },
 	  foldp : function(f) { return function(b) { return function(e) {
 		  return Elm.Fold(f,b,e); }; }; },
+	  foldp1 : function(f) { return function(b) { return function(e) {
+		  return Elm.Fold1(f,b,e); }; }; },
 	  count : function(sig){return Elm.Fold(function(_){return function(c){return c+1;};},0,sig)},
 	  keepIf : Elm.keepIf,
 	  dropIf : Elm.dropIf,

--- a/elm/src/Types/Hints.hs
+++ b/elm/src/Types/Hints.hs
@@ -131,7 +131,8 @@ signals =
     , sig 3 "lift2"
     , sig 4 "lift3"
     , sig 5 "lift4"
-    , "foldp" -:: (a ==> b ==> b) ==> b ==> signalOf a ==> signalOf b
+    , "foldp"     -:: (a ==> b ==> b) ==> b ==> signalOf a ==> signalOf b
+    , "foldp1"    -:: (a ==> b ==> b) ==> (a ==> b) ==> signalOf a ==> signalOf b
     , "randomize" -:: int ==> int ==> signalOf a ==> signalOf int
     , "count"     -:: signalOf a ==> signalOf int
     , "keepIf"    -:: (a==>bool) ==> a ==> signalOf a ==> signalOf a


### PR DESCRIPTION
This adds a variant of `foldp` that can be used when you need some input to produce an initial value:

```
foldp1 :: (a -> b -> b) -> (a -> b) -> Signal a -> Signal b
```

See the commit message for documentation.

Motivation: now we can run `Signal` data through a [Mealy machine](http://hackage.haskell.org/packages/archive/machines/latest/doc/html/Data-Machine-Mealy.html):

```
import Signal.Mouse  (clicks, x)

data Auto a b = Auto (a -> (b, Auto a b))

-- foldAuto :: Auto a b -> Signal a -> Signal b
foldAuto (Auto m0) input =
    lift fst $ foldp1 (\a (b, Auto m) -> m a) m0 input

-- summer :: Auto Int Int
summer =
    let go s = Auto (\n -> let s' = s+n in (s', go s'))
     in go 0

main = lift asText $ foldAuto summer $ sampleOn clicks $ constant 5
```

The first thing this program prints is `5`, which can only happen if the `summer` is fed an input before producing its output.

We can't do this with `foldp` alone.  This might not seem like an issue in practice, but it is if we want to write step functions using arrow composition.
### The Auto arrow

`Auto` is an arrow, allowing us to reap some of the benefits of arrowized FRP in Elm.  Consider a function for creating a draggable circle:

```
dragCircle :: Int           -- ^ Radius
           -> (Int, Int)    -- ^ Initial position
           -> Signal (Shape, (Int, Int))
```

This interface cannot be used to create circles dynamically, since that would involve changing the signal graph.  A more flexible version of `dragCircle` might look like:

```
dragCircleAuto :: Int -> (Int, Int)
               -> Auto ((Int, Int), Bool) (Shape, (Int, Int))
dragCircleAuto r c = Auto $ \(mousePos, mouseDown) ->
    ...

dragCircleInput :: Signal ((Int, Int), Bool)
dragCircleInput = lift2 (,) position isDown

dragCircle r c = foldAuto (dragCircleAuto r c) dragCircleInput
```

`dragCircleAuto` is a pure function, meaning it can be incorporated into a larger step function without the limitations of `Signal`.
