### PR TITLE
Compiler output directory

### DIFF
--- a/elm/src/Compiler.hs
+++ b/elm/src/Compiler.hs
@@ -69,8 +69,8 @@ fileTo isMini get what jsFiles noscript outputDir rtLoc file = do
     Left err -> putStrLn $ "Error while compiling " ++ file ++ ":\n" ++ err
     Right ms ->
         let path = case outputDir of
-		Nothing -> reverse . tail . dropWhile (/='.') $ reverse file
-		Just dir -> (\s -> dir ++ "/" ++ s) . reverse . takeWhile (/='/') . tail . dropWhile (/='.') $ reverse file
+                Nothing -> reverse . tail . dropWhile (/='.') $ reverse file
+                Just dir -> (\s -> dir ++ "/" ++ s) . reverse . takeWhile (/='/') . tail . dropWhile (/='.') $ reverse file
             js = path ++ ".js"
             html = path ++ ".html"
         in  case what of


### PR DESCRIPTION
Command line option for defining compilers output directory. Running compiler without that option specified defaults to behavior it had so far.

I don't have much haskell experience, so feel free to correct me if I did something against good practices ;)

Cheers!  
