### PR TITLE
use happstack 7.1.1

### DIFF
--- a/elm-server/elm-server.cabal
+++ b/elm-server/elm-server.cabal
@@ -32,7 +32,7 @@ Executable elm-server
                        parsec >= 3.1.1,
                        blaze-html >= 0.5.1,
                        HTTP >= 4000,
-                       happstack-server == 7.0.2,
+                       happstack-server == 7.1.1,
                        deepseq,
                        filepath,
                        Elm >= 0.6.0.3


### PR DESCRIPTION
Compiling Happstack 7.0.2 failed on my system for some reason. 7.1.1 seems to work fine with elm-server, and newer is better right? :)
