### PR TITLE
Use <button> instead of <input type="button">

### DIFF
--- a/core-js/Signal/Input.js
+++ b/core-js/Signal/Input.js
@@ -67,9 +67,9 @@ Elm.Input = function() {
 	return dropDown(Elm.List.map (function(x) {return Value.Tuple(x,x);}) (opts));
     };
     var button = function(name) {
-	var b = newElement('input');
+	var b = newElement('button');
 	b.type = "button";
-	b.value = JS.castStringToJSString(name);
+	b.innerText = JS.castStringToJSString(name);
 	var press = Elm.Signal.constant(false);
 	Value.addListener(b, 'click', function(e) {
 		Dispatcher.notify(press.id, true);


### PR DESCRIPTION
Fixes this bug: if you look at http://elm-lang.org/edit/examples/Intermediate/Form.elm in WebKit, at least, the button is always the same height right now, no matter what height / size you put on in Elm.

A little research shows that sticking with the input tag is fraught with problems and requires CSS hacking if you want to customize height:
http://stackoverflow.com/questions/1682520/css-how-to-increase-the-size-of-a-osx-submit-button
http://stackoverflow.com/questions/10976700/how-to-set-the-height-of-an-button-input-element-on-webkit-browsers
http://stackoverflow.com/questions/6184210/how-can-i-control-the-height-of-text-inputs-and-submit-buttons-in-different-brow

The button tag is allowed to have customizable height and is otherwise identical to the input tag in all modern browsers. (You could also embed HTML / styled text inside the button later, if you wanted.)
