### PR TITLE
Fix cabal install missing docs.json (followup)

### DIFF
--- a/Elm.cabal
+++ b/Elm.cabal
@@ -33,8 +33,6 @@ Library
   exposed-modules:     Language.Elm,
                        Language.Elm.Quasi
   Hs-Source-Dirs:      compiler, compiler/Gen, compiler/Model, compiler/Transform
-  extensions:          CPP
-  cpp-options:         -DELM_COMPILEDATADIR="dist/data"
   other-modules:       Ast,
                        Context,
                        CompileToJS,

--- a/compiler/Model/Libraries.hs
+++ b/compiler/Model/Libraries.hs
@@ -1,10 +1,8 @@
-{-# LANGUAGE TemplateHaskell #-}
-
 module Libraries (libraries) where
 
 import qualified Data.Map as Map
 import Text.JSON
-import LoadLibraries
+import LoadLibraries (docs)
 
 libraries :: Map.Map String (Map.Map String String)
 libraries = case getLibs of
@@ -13,7 +11,7 @@ libraries = case getLibs of
 
 getLibs :: Result (Map.Map String (Map.Map String String))
 getLibs = do
-  obj <- decodeStrict "{\"modules\":[]}" -- $(docs) :: Result (JSObject JSValue)
+  obj <- decodeStrict docs :: Result (JSObject JSValue)
   modules <- valFromObj "modules" obj :: Result [JSObject JSValue]
   Map.fromList `fmap` mapM getValues modules
 


### PR DESCRIPTION
Ok.  Been through everything wrt commit and discussion yesterday.
Think it's all done.

Biggest conceptual change is moving from using TemplateHaskell in LoadLibraries to loading docs.json at runtime.
This avoids using CPP, touch and other bits and replaces it with an "unsafeIO" to get the file loaded.

The other change is using process stuff in Setup.hs instead of the simpler system command.
