### PR TITLE
List.js minor bugfixes (for review)

### DIFF
--- a/libraries/Native/List.js
+++ b/libraries/Native/List.js
@@ -20,7 +20,7 @@ Elm.Native.List = function(elm) {
 
   function toArray(xs) {
     var out = [];
-    while (xs.ctor === "Cons") {
+    while (xs !== Nil) {
       out.push(xs._0);
       xs = xs._1;
     }
@@ -45,11 +45,11 @@ Elm.Native.List = function(elm) {
 
   function append(xs,ys) {
     if (typeof xs === "string") { return xs.concat(ys); }
-    if (xs.ctor === "Nil") { return ys; }
+    if (xs === Nil) { return ys; }
     var root = Cons(xs._0. Nil);
     var curr = root;
     xs = xs._1;
-    while (xs.ctor==="Cons") {
+    while (xs !== Nil) {
 	curr._1 = Cons(xs._0. Nil);
 	xs = xs._1;
 	curr = curr._1;
@@ -58,13 +58,13 @@ Elm.Native.List = function(elm) {
     return root;
   }
 
-  function head(v) { return v.ctor === "Nil" ? throwError('head') : v._0; }
-  function tail(v) { return v.ctor === "Nil" ? throwError('tail') : v._1; }
+  function head(v) { return v === Nil ? throwError('head') : v._0; }
+  function tail(v) { return v === Nil ? throwError('tail') : v._1; }
 
   function last(xs) {
-    if (xs.ctor === "Nil") { throwError('last'); }
+    if (xs === Nil) { throwError('last'); }
     var out = xs._0;
-    while (xs.ctor === "Cons") {
+    while (xs !== Nil) {
       out = xs._0;
       xs = xs._1;
     }
@@ -73,17 +73,19 @@ Elm.Native.List = function(elm) {
 
   function map(f, xs) {
     var arr = [];
-    while (xs.ctor === "Cons") {
+    while (xs !== Nil) {
       arr.push(f(xs._0));
       xs = xs._1;
     }
     return fromArray(arr);
   }
 
+   // f defined similarly for both foldl and foldr (NB: different from Haskell)
+   // ie, foldl :: (a -> b -> b) -> b -> [a] -> b
   function foldl(f, b, xs) {
     var acc = b;
-    while (xs.ctor === "Cons") {
-      acc = A2(f, acc, xs._0);
+    while (xs !== Nil) {
+      acc = A2(f, xs._0, acc);
       xs = xs._1;
     }
     return acc;
@@ -99,11 +101,11 @@ Elm.Native.List = function(elm) {
   }
 
   function foldl1(f, xs) {
-    return xs.ctor === "Nil" ? throwError('foldl1') : foldl(f, xs._0, xs._1);
+    return xs === Nil ? throwError('foldl1') : foldl(f, xs._0, xs._1);
   }
 
   function foldr1(f, xs) {
-    if (xs.ctor === "Nil") { throwError('foldr1'); }
+    if (xs === Nil) { throwError('foldr1'); }
     var arr = toArray(xs);
     var acc = arr.pop();
     for (var i = arr.length; i--; ) {
@@ -123,12 +125,12 @@ Elm.Native.List = function(elm) {
   }
 
   function scanl1(f, xs) {
-    return xs.ctor === "Nil" ? throwError('scanl1') : scanl(f, xs._0, xs._1);
+    return xs === Nil ? throwError('scanl1') : scanl(f, xs._0, xs._1);
   }
 
   function filter(pred, xs) {
     var arr = [];
-    while (xs.ctor === "Cons") {
+    while (xs !== Nil) {
       if (pred(xs._0)) { arr.push(xs._0); }
       xs = xs._1;
     }
@@ -137,7 +139,7 @@ Elm.Native.List = function(elm) {
 
   function length(xs) {
     var out = 0;
-    while (xs.ctor === "Cons") {
+    while (xs !== Nil) {
       out += 1;
       xs = xs._1;
     }
@@ -145,7 +147,7 @@ Elm.Native.List = function(elm) {
   }
 
   function member(x, xs) {
-    while (xs.ctor === "Cons") {
+    while (xs !== Nil) {
       if (Utils.eq(x,xs._0)) return true;
       xs = xs._1;
     }
@@ -155,7 +157,7 @@ Elm.Native.List = function(elm) {
   function reverse(xs) { return fromArray(toArray(xs).reverse()); }
 
   function concat(xss) {
-      if (xss.ctor === 'Nil') return xss;
+      if (xss === Nil) return xss;
       var arr = toArray(xss);
       var xs = arr[arr.length-1];
       for (var i = arr.length-1; i--; ) {
@@ -165,7 +167,7 @@ Elm.Native.List = function(elm) {
   }
 
   function all(pred, xs) {
-    while (xs.ctor === "Cons") {
+    while (xs !== Nil) {
       if (!pred(xs._0)) return false;
       xs = xs._1;
     }
@@ -173,7 +175,7 @@ Elm.Native.List = function(elm) {
   }
 
   function any(pred, xs) {
-    while (xs.ctor === "Cons") {
+    while (xs !== Nil) {
       if (pred(xs._0)) return true;
       xs = xs._1;
     }
@@ -182,7 +184,7 @@ Elm.Native.List = function(elm) {
 
   function zipWith(f, xs, ys) {
     var arr = [];
-    while (xs.ctor === "Cons" && ys.ctor === "Cons") {
+    while (xs !== Nil && ys !== Nil) {
       arr.push(A2(f, xs._0, ys._0));
       xs = xs._1;
       ys = ys._1;
@@ -192,7 +194,7 @@ Elm.Native.List = function(elm) {
 
   function zip(xs, ys) {
     var arr = [];
-    while (xs.ctor === "Cons" && ys.ctor === "Cons") {
+    while (xs !== Nil && ys !== Nil) {
       arr.push(Utils.Tuple2(xs._0, ys._0));
       xs = xs._1;
       ys = ys._1;
@@ -202,15 +204,15 @@ Elm.Native.List = function(elm) {
 
   function sort(xs) {
     function cmp(a,b) {
-      var ord = Utils.compare(a,b);
-      return ord.ctor === 'EQ' ? 0 : ord.ctor === 'LT' ? -1 : 1;
+      var ord = Utils.compare(a,b).ctor;
+      return ord=== 'EQ' ? 0 : ord === 'LT' ? -1 : 1;
     }
     return fromArray(toArray(xs).sort(cmp));
   }
 
   function take(n, xs) {
     var arr = [];
-    while (xs.ctor === "Cons" && n > 0) {
+    while (xs !== Nil && n > 0) {
       arr.push(xs._0);
       xs = xs._1;
       --n;
@@ -219,7 +221,7 @@ Elm.Native.List = function(elm) {
   }
 
   function drop(n, xs) {
-    while (xs.ctor === "Cons" && n > 0) {
+    while (xs !== Nil && n > 0) {
       xs = xs._1;
       --n;
     }
@@ -227,11 +229,11 @@ Elm.Native.List = function(elm) {
   }
 
   function join(sep, xss) {
-    if (xss.ctor === 'Nil') return Nil;
+    if (xss === Nil) return Nil;
     var s = toArray(sep);
     var out = toArray(xss._0);
     xss = xss._1;
-    while (xss.ctor === "Cons") {
+    while (xss !== Nil) {
       out = out.concat(s, toArray(xss._0));
       xss = xss._1;
     }


### PR DESCRIPTION
If you're ok with this so far then good, otherwise let me know:
## 

freeze Nil (one-time overhead for marginal safety)
don't do this for Cons (huge performance overhead)

use Nil throughout instead of making our own (if we're having a singleton, we should be consistently using it)

missing A2, A3 in places.

foldl function applied args in wrong order, foldl :: (a -> b -> a) -> a -> [b] -> a
sort: missing .ctor selector
