### PR TITLE
Singleton Nil consequential change to compiler (minor)

### DIFF
--- a/compiler/Gen/CompileToJS.hs
+++ b/compiler/Gen/CompileToJS.hs
@@ -223,8 +223,11 @@ instance ToJS Expr where
     Let defs e -> jsLet defs e
     Data name es ->
         do fs <- mapM toJS' es
-           let fields = zipWith (\n e -> "_" ++ show n ++ ":" ++ e) [0..] fs
-           return (brackets ("ctor:" ++ show name ++ concatMap (", "++) fields))
+           return $ case name of
+              "Nil" -> jsNil
+              "Cons" -> jsCons (head fs) ((head . tail) fs)
+              _ -> brackets $ "ctor:" ++ show name ++ concatMap (", "++) fields
+                   where fields = zipWith (\n e -> "_" ++ show n ++ ":" ++ e) [0..] fs
 
     Markdown doc -> return $ "text('" ++ pad ++ md ++ pad ++ "')"
         where pad = "<div style=\"height:0;width:0;\">&nbsp;</div>"


### PR DESCRIPTION
CompileToJS generates objects using "ctor:"... for all non-primitives.
Added special handling for lists

Might be better to have a separate tag instead of: Data "Nil"

Test case:
main_join = let f x xs = (x::xs)
    in asText $ zipWith f ['c','m','t'] ["hop","ill","ape"]

 before fails with "xs: undefined".
