### PR TITLE
Fix showing compilation errors in the browser

### DIFF
--- a/compiler/Gen/GenerateHtml.hs
+++ b/compiler/Gen/GenerateHtml.hs
@@ -44,7 +44,7 @@ generateHtml libLoc title source =
   case buildFromSource True source of
     Right modul -> modulesToHtml Readable title libLoc [] True [modul]
     Left err -> createHtml Readable libLoc title (Right $ showErr err)
-                (H.noscript "") "Elm.Main"
+                (H.noscript "") "Main"
 
 
 modulesToHtml jsStyle title libLoc jss nscrpt modules =


### PR DESCRIPTION
- "Elm." is already prepended by https://github.com/evancz/Elm/blob/dev/compiler/Gen/GenerateHtml.hs#L74
