### PR TITLE
Found to '$' replace with '<|'

### DIFF
--- a/libraries/Automaton.elm
+++ b/libraries/Automaton.elm
@@ -33,7 +33,7 @@ g <<< f = f >>> g
 -- Combine a list of automatons into a single automaton that produces a list.
 combine : [Automaton a b] -> Automaton a [b]
 combine autos =
-  Step (\a -> let (autos', bs) = unzip $ map (step a) autos
+  Step (\a -> let (autos', bs) = unzip <| map (step a) autos
               in  (combine autos', bs))
 
 -- Create an automaton with no memory. It just applies the given function to

--- a/libraries/Dict.elm
+++ b/libraries/Dict.elm
@@ -154,7 +154,7 @@ find k t =
 -- Determine if a key is in a dictionary.
 member : Comparable k -> Dict (Comparable k) v -> Bool
 -- Does t contain k?
-member k t = Maybe.isJust $ lookup k t
+member k t = Maybe.isJust <| lookup k t
 
 rotateLeft : Dict k v -> Dict k v
 rotateLeft t =


### PR DESCRIPTION
Hi Evan,

this bug also exists on the dev branch.

It highlights a problem that undefined operators are not caught by the typechecker? Or is it just because '$' used to be a built-in operator?

Now that I found the problem, the runtime error makes sense. But it took some git bisecting to get to that understanding.

Mads
