### PR TITLE
Fix an issue with missing build-depends (shakespeare, text, template-haskell)

### DIFF
--- a/Elm.cabal
+++ b/Elm.cabal
@@ -85,6 +85,9 @@ Library
                        mtl >= 2,
                        pandoc >= 1.10,
                        parsec >= 3.1.1,
+                       shakespeare,
+                       template-haskell,
+                       text,
                        transformers >= 0.2,
                        union-find,
                        uniplate
@@ -143,6 +146,9 @@ Executable elm
                        mtl >= 2,
                        pandoc >= 1.10,
                        parsec >= 3.1.1,
+                       shakespeare,
+                       template-haskell,
+                       text,
                        transformers >= 0.2,
                        union-find,
                        uniplate


### PR DESCRIPTION
The dev branch is missing some needed dependencies, which breaks the build and makes the branch unusable. This change adds those dependencies so the branch can once again be built and tested.
