### PR TITLE
Fix bug where ExplicitList wasn't handled by subst

### DIFF
--- a/compiler/Parse/Pattern.hs
+++ b/compiler/Parse/Pattern.hs
@@ -14,7 +14,6 @@ import Parse.Literal
 import qualified SourceSyntax.Pattern as Pattern
 import SourceSyntax.Everything hiding (parens, tuple)
 
-
 basic :: IParser Pattern
 basic = choice
     [ char '_' >> return PAnything

--- a/compiler/Transform/Optimize.hs
+++ b/compiler/Transform/Optimize.hs
@@ -3,6 +3,7 @@ module Transform.Optimize (optimize) where
 import SourceSyntax.Everything
 import Control.Arrow (second, (***))
 import Data.Char (isAlpha)
+import Data.Data
 import Transform.Substitute
 
 optimize (Module name ims exs stmts) =
@@ -14,12 +15,12 @@ optimizeStmt stmt = if stmt == stmt' then stmt' else optimizeStmt stmt'
 class Simplify a where
   simp :: a -> a
 
-instance Simplify (Declaration t v) where
+instance (Data t, Data v) => Simplify (Declaration t v) where
   simp (Definition def) = Definition (simp def)
   simp (ImportEvent js b elm t) = ImportEvent js (simp b) elm t
   simp stmt = stmt
 
-instance Simplify (Def t v) where
+instance (Data t, Data v) => Simplify (Def t v) where
   simp (FnDef func args e) = FnDef func args (simp e)
   simp (OpDef op a1 a2 e)  = OpDef op a1 a2 (simp e)
   simp x = x
@@ -27,7 +28,7 @@ instance Simplify (Def t v) where
 instance Simplify e => Simplify (Located e) where
   simp (L t s e) = L t s (simp e)
 
-instance Simplify (Expr t v) where
+instance (Data t, Data v) => Simplify (Expr t v) where
   simp expr =
     let f = simp in
     case expr of

--- a/compiler/Transform/Substitute.hs
+++ b/compiler/Transform/Substitute.hs
@@ -2,27 +2,13 @@ module Transform.Substitute (subst) where
 
 import SourceSyntax.Expression
 import SourceSyntax.Location
-import Control.Arrow (second, (***))
+import Data.Generics.Uniplate.Data
+import Data.Data
 
-subst :: String -> Expr t v -> Expr t v -> Expr t v
+subst :: (Data t, Data v) => String -> Expr t v -> Expr t v -> Expr t v
 subst old new expr =
-    let f (L t s e) = L t s (subst old new e) in
-    case expr of
-      Range e1 e2 -> Range (f e1) (f e2)
-      Access e x -> Access (f e) x
-      Remove e x -> Remove (f e) x
-      Insert e x v -> Insert (f e) x (f v)
-      Modify r fs -> Modify (f r) (map (second f) fs)
-      Record fs -> Record (map (\(lbl,as,e) -> (lbl,as,f e)) fs)
-      Binop op e1 e2 -> Binop op (f e1) (f e2)
-      Lambda x e -> if x == old then expr else Lambda x (f e)
-      App e1 e2 -> App (f e1) (f e2)
-      MultiIf ps -> MultiIf (map (f *** f) ps)
-      Let defs e -> Let (map substDef defs) (f e)
-              where substDef (FnDef name vs e)  = FnDef name vs (f e)
-                    substDef (OpDef op a1 a2 e) = OpDef op a1 a2 (f e)
-                    substDef x = x
-      Var x -> if x == old then new else expr
-      Case e cases -> Case (f e) $ map (second f) cases
-      Data name es -> Data name (map f es)
-      _ -> expr
+  transformBi substOne expr
+    where
+      substOne x@(Lambda name e) | name == old = new
+      substOne x@(Var name)      | name == old = new
+      substOne x = x


### PR DESCRIPTION
This change makes subst use transformBi from Uniplate using Data.Data, which
required some changes throughout the codebase to ensure the compiler can
correctly infer the type.
