### PR TITLE
Keep last drawn current scene when cancelling an animation frame.

### DIFF
--- a/runtime/Init.js
+++ b/runtime/Init.js
@@ -155,10 +155,10 @@ function initGraphics(elm, Module) {
   
   // set up updates so that the DOM is adjusted as necessary.
   function domUpdate(newScene, currentScene) {
-      ElmRuntime.draw(function(_) {
+      ElmRuntime.draw(function(currentScene, newScene) {
               Render.update(elm.node.firstChild, currentScene, newScene);
               if (elm.Native.Window) elm.Native.Window.resizeIfNeeded();
-          });
+            }, currentScene, newScene);
       return newScene;
   }
   return A3(Signal.foldp, F2(domUpdate), currentScene, signalGraph);

--- a/runtime/Utils.js
+++ b/runtime/Utils.js
@@ -41,13 +41,19 @@ for (var i = 0; i < vendors.length && !window.requestAnimationFrame; ++i) {
 }
 
 if (window.requestAnimationFrame && window.cancelAnimationFrame) {
-    var previous = 0;
-    ElmRuntime.draw = function(callback) {
-        window.cancelAnimationFrame(previous);
-        previous = window.requestAnimationFrame(callback);
+    var previous = {};
+    ElmRuntime.draw = function(callback, currentScene, newScene) {
+        if (previous.currentScene == null)
+            previous.currentScene = currentScene;
+        if (previous.frame != null)
+            window.cancelAnimationFrame(previous.frame);
+        previous.frame = window.requestAnimationFrame(function() {
+            callback(previous.currentScene, newScene);
+            previous.currentScene = newScene;
+        });
     };
 } else {
-    ElmRuntime.draw = function(callback) { callback(); };
+    ElmRuntime.draw = function(callback, currentScene, newScene) { callback(currentScene, newScene); };
 }
 
 }());


### PR DESCRIPTION
Without this change, in browsers with requestAnimationFrame support,
if a second frame is generated before the first frame has been
rendered, the 'current' scene for the rendering is the new scene
from the frame that was never rendered, which means that changes from
that scene never get picked up.

Fixes Elm issue 189 - https://github.com/evancz/Elm/issues/189

Note of level of testing: I have only had time to do rudimentary testing to check that this fixes my testcase from Elm issue 189 - it would be good if someone had the time to test it more fully, particularly on a browser that doesn't support requestAnimationFrame.
