### PR TITLE
Move variable renaming later in compilation.

### DIFF
--- a/Elm.cabal
+++ b/Elm.cabal
@@ -52,6 +52,7 @@ Library
                        Transform.SortDefinitions,
                        Transform.Substitute,
                        Transform.Optimize,
+                       Transform.Variable
                        Metadata.Prelude,
                        Initialize,
                        Parse.Binop,
@@ -122,6 +123,7 @@ Executable elm
                        Transform.SortDefinitions,
                        Transform.Substitute,
                        Transform.Optimize,
+                       Transform.Variable,
                        Metadata.Prelude,
                        Initialize,
                        Parse.Binop,

--- a/compiler/Parse/Helpers.hs
+++ b/compiler/Parse/Helpers.hs
@@ -64,18 +64,10 @@ rLabel = lowVar
 innerVarChar :: IParser Char
 innerVarChar = alphaNum <|> char '_' <|> char '\'' <?> "" 
 
-makeSafe :: String -> String
-makeSafe = dereserve . deprime
-  where
-    deprime = map (\c -> if c == '\'' then '$' else c)
-    dereserve x = case Set.member x jsReserveds of
-                    False -> x
-                    True  -> "$" ++ x
-
 makeVar :: IParser Char -> IParser String
 makeVar p = do v <- (:) <$> p <*> many innerVarChar
                guard (v `notElem` reserveds)
-               return (makeSafe v)
+               return v
 
 reserved :: String -> IParser String
 reserved word =
@@ -233,3 +225,4 @@ closeComment = do
                , do { try $ string "{-"; closeComment; closeComment }
                ]
     return ("{-" ++ comment ++ "-}")
+

--- a/compiler/SourceSyntax/Module.hs
+++ b/compiler/SourceSyntax/Module.hs
@@ -35,7 +35,7 @@ data MetadataModule t v = MetadataModule {
     datatypes :: [ (String, [String], [(String,[Type])]) ],
     foreignImports :: [(String, LExpr t v, String, Type)],
     foreignExports :: [(String, String, Type)]
-}
+} deriving Show
 
 type Interfaces = Map.Map String ModuleInterface
 type ADT = (String, [String], [(String,[Type])])

--- a/compiler/SourceSyntax/PrettyPrint.hs
+++ b/compiler/SourceSyntax/PrettyPrint.hs
@@ -17,7 +17,4 @@ parensIf bool doc = if bool then parens doc else doc
 
 variable x =
     if Help.isOp x then parens (text x)
-                   else text (reprime x)
-
-reprime :: String -> String
-reprime = map (\c -> if c == '$' then '\'' else c)
+                   else text x

--- a/compiler/Transform/Variable.hs
+++ b/compiler/Transform/Variable.hs
@@ -1,0 +1,77 @@
+{-# OPTIONS_GHC -Wall #-}
+module Transform.Variable where
+
+import Parse.Helpers (jsReserveds)
+import SourceSyntax.Expression
+import SourceSyntax.Location
+import SourceSyntax.Module
+import SourceSyntax.Pattern
+
+import Data.Map (mapKeys)
+import qualified Data.Set as Set
+import Control.Arrow (second, (***))
+
+-- Make all variable names acceptable JavaScript identifiers
+makeVarsSafe :: MetadataModule t v -> MetadataModule t v
+makeVarsSafe modul = modul {
+  names = map makeSafe $ names modul
+  , exports = map makeSafe $ exports modul
+  , imports = map (makeSafe *** mapVarImports makeSafe) $ imports modul
+  , program = mapVarExpr makeSafe $ program modul
+  , types   = mapKeys makeSafe $ types modul
+  , aliases = map (squish3 makeSafe (map makeSafe) id) $ aliases modul
+  , datatypes = map (squish3 makeSafe (map makeSafe) (map (makeSafe *** id))) $ datatypes modul
+  , foreignImports = map (squish4 id (mapVarExpr makeSafe) makeSafe id) $ foreignImports modul
+  , foreignExports = map (squish3 id makeSafe id) $ foreignExports modul
+  }
+  where squish3 f1 f2 f3 (x, y, z) = (f1 x, f2 y, f3 z)
+        squish4 f1 f2 f3 f4 (w, x, y, z) = (f1 w, f2 x, f3 y, f4 z)
+
+makeSafe :: String -> String
+makeSafe = dereserve . deprime
+  where
+    deprime = map (\c -> if c == '\'' then '$' else c)
+    dereserve x = case Set.member x jsReserveds of
+                    False -> x
+                    True  -> "$" ++ x
+
+-- Change the name of every variable
+mapVarExpr :: (String -> String) -> LExpr t v -> LExpr t v
+mapVarExpr f lexpr = rec lexpr
+  where rec (L s e') = L s $ case e' of
+          Var x -> Var (f x)
+          Range e1 e2 -> Range (rec e1) (rec e2)
+          ExplicitList es -> ExplicitList (map rec es)
+          Binop op e1 e2 -> Binop op (rec e1) (rec e2)
+          Lambda p e -> Lambda (fPat p) (rec e)
+          App e1 e2 -> App (rec e1) (rec e2)
+          MultiIf ps -> MultiIf (map (rec *** rec) ps)
+          Let defs body -> Let (map recDef defs) (rec body)
+            where recDef (Def name e)  = Def (fPat name) (rec e)
+                  recDef anno@(TypeAnnotation _ _) = anno
+          Case e cases -> Case (rec e) $ map (fPat *** rec) cases
+          Data name es -> Data name (map rec es)
+          Access e x -> Access (rec e) x
+          Remove e x -> Remove (rec e) x
+          Insert e x v -> Insert (rec e) x (rec v)
+          Modify r fs -> Modify (rec r) (map (second rec) fs)
+          Record fs -> Record (map (second rec) fs)
+          Literal _ -> e'
+          Markdown _ -> e'
+        fPat = mapVarPat f
+
+mapVarPat :: (String -> String) -> Pattern -> Pattern
+mapVarPat f pat = rec pat
+  where rec p' = case p' of
+          PData s ps -> PData (f s) (map rec ps)
+          PRecord ss -> PRecord ss
+          PAlias s p -> PAlias (f s) (rec p)
+          PVar s     -> PVar (f s)
+          PAnything  -> p'
+          PLiteral _ -> p'
+
+mapVarImports :: (String -> String) -> ImportMethod -> ImportMethod
+mapVarImports f im = case im of
+  As s         -> As (f s)
+  Importing ss -> Importing (map f ss)
+  Hiding ss    -> Hiding (map f ss)

--- a/compiler/Type/PrettyPrint.hs
+++ b/compiler/Type/PrettyPrint.hs
@@ -2,7 +2,6 @@
 module Type.PrettyPrint where
 
 import Text.PrettyPrint
-import qualified SourceSyntax.PrettyPrint as Src
 
 data ParensWhen = Fn | App | Never
 
@@ -12,5 +11,3 @@ class PrettyType a where
 commaSep docs = sep (punctuate comma docs)
 
 parensIf bool doc = if bool then parens doc else doc
-
-reprime = Src.reprime

--- a/compiler/Type/Type.hs
+++ b/compiler/Type/Type.hs
@@ -177,7 +177,7 @@ instance PrettyType a => PrettyType (Term1 a) where
           prettyExt = prty ext
           extend | P.render prettyExt == "{}" = P.empty
                  | otherwise = prettyExt <+> P.text "|"
-          mkPretty f t = P.text (reprime f) <+> P.text ":" <+> prty t
+          mkPretty f t = P.text f <+> P.text ":" <+> prty t
           prettyFields = concatMap (\(f,ts) -> map (mkPretty f) ts) (Map.toList fields)
 
 
@@ -192,7 +192,7 @@ instance PrettyType Descriptor where
   pretty when desc =
     case (structure desc, name desc) of
       (Just term, _) -> pretty when term
-      (_, Just name) -> if not (isTuple name) then P.text (reprime name) else
+      (_, Just name) -> if not (isTuple name) then P.text name else
                             P.parens . P.text $ replicate (read (drop 6 name) - 1) ','
       _ -> P.text "?"
 


### PR DESCRIPTION
Moves variable renaming to the code generation phase.

This fixes all bugs in depriming in type errors, and also makes the parser more modular.
