### PR TITLE
Convert Keyboard docs.

### DIFF
--- a/libraries/Keyboard.elm
+++ b/libraries/Keyboard.elm
@@ -1,57 +1,76 @@
 module Keyboard where
 
+{-| Library for working with keyboard input.
+
+# Representing Keys
+@docs KeyCode
+
+# Directions
+@docs arrows, wasd, directions
+
+# Specific Keys
+@docs shift, enter, space, ctrl
+
+# General Keypresses
+@docs isDown, keysDown, lastPressed
+
+-}
+
 import Signal (Signal)
 import Native.Keyboard
 
--- Type alias to make it clearer what integers are supposed to represent
--- in this library. Use [`Char.toCode`](docs/Char.elm#toCode) and
--- [`Char.fromCode`](/docs/Char.elm#fromCode) to convert key codes to characters.
+{-| Type alias to make it clearer what integers are supposed to represent
+ in this library. Use [`Char.toCode`](docs/Char.elm#toCode) and
+ [`Char.fromCode`](/docs/Char.elm#fromCode) to convert key codes to characters.
+ Use the uppercase character with `toCode`. -}
 type KeyCode = Int
 
--- Custom key directions so that you can support different locales.
+{-| Custom key directions to support different locales. The order is up, down,
+left, right. -}
 -- The plan is to have a locale independent version of this function
 -- that uses the physical location of keys, but I don't know how to do it.
 directions : KeyCode -> KeyCode -> KeyCode -> KeyCode -> Signal { x:Int, y:Int }
 directions = Native.Keyboard.directions
 
--- A signal of records indicating which arrow keys are pressed.
---
--- `{ x = 0, y = 0 }` when pressing no arrows.<br>
--- `{ x =-1, y = 0 }` when pressing the left arrow.<br>
--- `{ x = 1, y = 1 }` when pressing the up and right arrows.<br>
--- `{ x = 0, y =-1 }` when pressing the down, left, and right arrows.
+{-| A signal of records indicating which arrow keys are pressed.
+
+ `{ x = 0, y = 0 }` when pressing no arrows.<br>
+ `{ x =-1, y = 0 }` when pressing the left arrow.<br>
+ `{ x = 1, y = 1 }` when pressing the up and right arrows.<br>
+ `{ x = 0, y =-1 }` when pressing the down, left, and right arrows.
+-}
 arrows : Signal { x:Int, y:Int }
 arrows = directions 38 40 37 39
 
--- Just like the arrows signal, but this uses keys w, a, s, and d,
--- which are common controls for many computer games.
+{-| Just like the arrows signal, but this uses keys w, a, s, and d,
+which are common controls for many computer games. -}
 wasd : Signal { x:Int, y:Int }
 wasd = directions 87 83 65 68
 
--- Whether an arbitrary key is pressed.
+{-| Whether an arbitrary key is pressed. -}
 isDown : KeyCode -> Signal Bool
 isDown = Native.Keyboard.isDown
 
--- Whether the shift key is pressed.
+{-| Whether the shift key is pressed. -}
 shift : Signal Bool
 shift = isDown 16
 
--- Whether the control key is pressed.
+{-| Whether the control key is pressed. -}
 ctrl : Signal Bool
 ctrl = isDown 17
 
--- Whether the space key is pressed.
+{-| Whether the space key is pressed. -}
 space : Signal Bool
 space = isDown 32
 
--- Whether the enter key is pressed.
+{-| Whether the enter key is pressed. -}
 enter : Signal Bool
 enter = isDown 13
 
--- List of keys that are currently down.
+{-| List of keys that are currently down. -}
 keysDown : Signal [KeyCode]
 keysDown = Native.Keyboard.keysDown
 
--- The latest key that has been pressed.
+{-| The latest key that has been pressed. -}
 lastPressed : Signal KeyCode
 lastPressed = Native.Keyboard.lastPressed


### PR DESCRIPTION
Should `KeyCode` be abstracted out? There's the pitfall of using `toCode 'c'` instead of `toCode 'C'`. Then there's the ability to, with a bit more work, figure out if shift and/or caps lock are down and return that a capital letter was pressed, which ought to make text entry easier. But I suppose it makes localization difficult.

Anyway, this is another straightforward conversion.
