### PR TITLE
Fix cabal configure in Cabal version 1.18.

### DIFF
--- a/Setup.hs
+++ b/Setup.hs
@@ -83,16 +83,6 @@ filterExe name pd = pd {
     executables = filter (\x -> (exeName x == name)) (executables pd)
     }
 
--- It's not enough to fix the PackageDescription, we also have to fix the
--- LocalBuildInfo. This includes the component build order (data ComponentName)
--- which is horribly internal.
-filterLBI :: String -> LocalBuildInfo -> LocalBuildInfo
-filterLBI name lbi = lbi {
-    libraryConfig = Nothing,
-    compBuildOrder = [CExeName name],
-    executableConfigs = filter (\a -> (fst a == name)) (executableConfigs lbi)
-    }
-
 
 -- Post Build
 


### PR DESCRIPTION
Prior to this commit the configure command fails on Cabal 1.18 with the
following error:

```
Setup.hs:91:5:
    `libraryConfig' is not a (visible) constructor field name

Setup.hs:92:5:
    `compBuildOrder' is not a (visible) constructor field name

Setup.hs:93:5:
    `executableConfigs' is not a (visible) constructor field name

Setup.hs:93:57: Not in scope: `executableConfigs'
```

This commit removes `filterLBI` in Setup.hs that called functions that have been
removed from Cabal. Deleting this function shouldn't affect compilation since it
seems to be unused anyway: `filterLBI`, was added in commit 14e32ad on Thu Mar
21 2013 and the only reference to it was removed on Sun Jul 28 in commit
0a6bd8bd96.

After this change elm compiles for me on Cabal 1.18.0 and 1.16.0.
