### PR TITLE
Fix runtime error with Random.float.

### DIFF
--- a/libraries/Native/Signal/Random.js
+++ b/libraries/Native/Signal/Random.js
@@ -17,7 +17,7 @@ Elm.Native.Random = function(elm) {
   }
 
   elm.Native.Random = { range: F3(range) };
-  elm.Native.Random['float'] = flt;
+  elm.Native.Random['flt'] = flt;
   return elm.Native.Random;
 
 };

--- a/libraries/Random.elm
+++ b/libraries/Random.elm
@@ -20,4 +20,4 @@ range = Native.Random.range
 The new values are random numbers in [0..1).
 -}
 float : Signal a -> Signal Float
-float = Native.Random.float
+float = Native.Random.flt


### PR DESCRIPTION
Rename JS function to avoid conflicting with reserved words, as enforced by
commit 40ea6df24 (found with `git bisect`).

The bug can be minified as far as

```
import Random
main = asText <~ Random.float (fps 2)
```
