### PR TITLE
Relax mtime test in alreadyCompiled

### DIFF
--- a/compiler/Compiler.hs
+++ b/compiler/Compiler.hs
@@ -118,7 +118,7 @@ buildFile flags moduleNum numModules interfaces filePath =
             then return False
             else do tsrc <- getModificationTime filePath
                     tint <- getModificationTime (elmo flags filePath)
-                    return (tsrc < tint)
+                    return (tsrc <= tint)
 
       number :: String
       number = "[" ++ show moduleNum ++ " of " ++ show numModules ++ "]"


### PR DESCRIPTION
If an elmi or elmo file is created at the same time as the elm file, alreadyCompiled always returns False. In NixOS this is problematic since all files in the Nix store, a safe place to store packages, all files have the same mtime (1. Jan 1970). So for the Nix build support [1] we have to relax this test by allowing that source and output file may have the same mtime.

While this can be easily patched for this particular use case, I opt for this change to be in upstream.

[1] https://github.com/aforemny/nixpkgs/tree/elm-build-support
