### PR TITLE
Improve error messages when elm input file or binary can't be found

### DIFF
--- a/server/Server.hs
+++ b/server/Server.hs
@@ -1,4 +1,3 @@
-
 module Main where
 
 import Control.Monad (msum,guard,when)
@@ -64,7 +63,7 @@ serveElm fp = do
         args = [ "--make" ,"--runtime=" ++ runtime,
                  "--cache-dir=" ++ defaultCacheDirectory, file ]
 
-serveLib :: FilePath -> [Char] -> ServerPartT IO Response
+serveLib :: FilePath -> String -> ServerPartT IO Response
 serveLib libLoc fp = do
   guard (fp == runtime)
   serveFile (asContentType "application/javascript") libLoc
@@ -76,9 +75,11 @@ parse :: [String] -> IO ()
 parse ("--help":_) = putStrLn usage
 parse ("--version":_) = putStrLn ("The Elm Server " ++ showVersion version)
 parse args =
-  case null remainingArgs of
-    True -> serve portNumber =<< elmRuntime
-    False -> putStrLn usageMini
+  if null remainingArgs then
+      serve portNumber =<< elmRuntime
+  else
+      putStrLn usageMini
+
   where
     runtimeArg = filter (isPrefixOf "--runtime-location=") args
     portArg = filter (isPrefixOf "--port=") args


### PR DESCRIPTION
When the elm binary can't be found or the requested file ends in .elm but the file does not exist the server returns the following unhelpful message:

```
Server error: elm-server-cache: getDirectoryContents: does not exist (No such file or directory)
```

This PR improves the error messages in the above two cases, and also returns a correct 404 response when a file ending in .elm is unable to be located in the filesystem. 

Finally, there are a couple of minor tweaks based on hlint's suggestions for the `Server.hs` file.
