### PR TITLE
Print types even when the elm file has already been compiled.

### DIFF
--- a/compiler/Transform/Canonicalize.hs
+++ b/compiler/Transform/Canonicalize.hs
@@ -20,6 +20,7 @@ interface :: String -> ModuleInterface -> ModuleInterface
 interface moduleName iface =
     ModuleInterface
     { iTypes = Map.mapKeys prefix (Map.map renameType' (iTypes iface))
+    , iImports = iImports iface
     , iAdts = map (both prefix renameCtors) (iAdts iface)
     , iAliases = map (both prefix renameType') (iAliases iface)
     , iFixities = iFixities iface -- cannot have canonicalized operators while parsing

--- a/compiler/Type/Inference.hs
+++ b/compiler/Type/Inference.hs
@@ -52,7 +52,7 @@ infer interfaces modul = unsafePerformIO $ do
     Left err -> return $ Left err
     Right (header, constraint) -> do
       state <- execStateT (Solve.solve constraint) TS.initialState
-      let rules = Alias.rules interfaces modul
+      let rules = Alias.rules interfaces (aliases modul) (imports modul)
       case TS.sErrors state of
         errors@(_:_) -> Left `fmap` sequence (map ($ rules) (reverse errors))
         [] -> extraChecks rules (Map.difference (TS.sSavedEnv state) header)


### PR DESCRIPTION
This fixes #299, where types are not printed even when the `--print-types` option is given for an elm file that has already been compiled.

The bug of printing types could have been easily fixed by always triggering compilation when `--print-types` is given, but that seems kludgy and I felt like types should either be printable with or without existing elmi files.

Before merging this, I'd like feedback on the two following issues:
1. Is there a way to do this without having to serialize the `imports` in the `elmi` file? I looked around for a bit but I don't have a deep enough understanding of the how this part of the project works to figure out how to do it another way. We shouldn't add this to the serialized program representation unless necessary.
2. There is a slight difference in output when printing types before and after the file has been compiled. My printing of types afterwards includes the namespace and I wasn't able to figure out how to remove this. Any suggestions would be appreciated. Output with and without existing elmi files below:

Without existing elmi file:

```
justin ~/Code/elm-lang.org/public/examples/Intermediate $ elm --print-types Bounce.elm 
[1 of 1] Compiling Main                ( Bounce.elm )

ball : Signal {height : Float, velocity : Float}
bounceVelocity : number
draw : {a | height : Float} -> Element
gravity : number
main : Signal Element
step : number
       -> {a | height : number, velocity : number}
       -> {a | height : number, velocity : number}

Generating HTML ... Done
```

With existing elmi file:

```
justin ~/Code/elm-lang.org/public/examples/Intermediate $ elm --print-types Bounce.elm 

Main.ball : Signal {height : Float, velocity : Float}
Main.bounceVelocity : number
Main.draw : {a | height : Float} -> Element
Main.gravity : number
Main.main : Signal Element
Main.step : number
            -> {a | height : number, velocity : number}
            -> {a | height : number, velocity : number}

Generating HTML ... Done
```

Finally note that adding this field would break deserialization of any existing .elmi files before this commit. I was thinking it would be nice to add a compiler version, and perhaps SHA of the .elm file being serialized to make our detection of when recompilation is needed more robust. I spent quite a while today figuring out why I couldn't deserialize a version of Prelude that had been written by the previous compiler before my change. That's for another PR though.
