### PR TITLE
can have zero fields if no extension could be parsed

### DIFF
--- a/compiler/Parse/Type.hs
+++ b/compiler/Parse/Type.hs
@@ -26,7 +26,9 @@ record :: IParser T.Type
 record =
   do char '{' ; whitespace
      ext <- extend
-     fs <- fields
+     fs <- case ext of
+        T.EmptyRecord -> commaSep fields
+        _ -> commaSep1 fields
      dumbWhitespace ; char '}'
      return (T.Record fs ext)
   where
@@ -34,7 +36,7 @@ record =
                t <- tvar
                whitespace >> string "|" >> whitespace
                return t
-    fields = commaSep1 $ do
+    fields = do
                lbl <- rLabel
                whitespace >> hasType >> whitespace
                (,) lbl <$> expr


### PR DESCRIPTION
https://github.com/evancz/Elm/issues/305

The idea being that if we can't parse the base record and the pipe, then this must be a concrete record, and zero fields is valid.
