### PR TITLE
type annotation of String.isEmpty: "isEmpty : String" => isEmpty : Strin...

### DIFF
--- a/libraries/String.elm
+++ b/libraries/String.elm
@@ -32,7 +32,7 @@ import Native.String
 import Maybe (Maybe)
 
 {-| Check if a string is empty `(isEmpty "" == True)` -}
-isEmpty : String
+isEmpty : String -> Bool
 isEmpty = Native.String.isEmpty
 
 {-| Add a character to the beginning of a string -}


### PR DESCRIPTION
I guess
String.isEmpty : String
should be
String.isEmpty : String -> Bool
