### PR TITLE
Load interfaces in IO monad

### DIFF
--- a/compiler/Compiler.hs
+++ b/compiler/Compiler.hs
@@ -21,7 +21,7 @@ import qualified Metadata.Prelude as Prelude
 import qualified Transform.Canonicalize as Canonical
 import SourceSyntax.Module
 import Parse.Module (getModuleName)
-import Initialize (buildFromSource, getSortedDependencies)
+import Initialize (buildFromSource, getSortedDependencies, requiredInterfaces)
 import Generate.JavaScript (jsModule)
 import Generate.Html (createHtml, JSSource(..))
 import qualified InterfaceSerialization as IS
@@ -186,7 +186,7 @@ build flags rootFile = do
   let noPrelude = no_prelude flags
   files <- if make flags then getSortedDependencies (src_dir flags) noPrelude rootFile
                          else return [rootFile]
-  let ifaces = if noPrelude then Map.empty else Prelude.interfaces
+  ifaces <- requiredInterfaces noPrelude
   (moduleName, interfaces) <- buildFiles flags (length files) ifaces "" files
   js <- foldM appendToOutput BS.empty files
 

--- a/compiler/Language/Elm.hs
+++ b/compiler/Language/Elm.hs
@@ -21,11 +21,12 @@ import Paths_Elm
 
 -- |This function compiles Elm code to JavaScript. It will return either
 --  an error message or the compiled JS code.
-compile :: String -> Either String String
-compile source =
-    case buildFromSource False Prelude.interfaces source of
-      Left docs -> Left . unlines . List.intersperse "" $ map P.render docs
-      Right modul -> Right $ jsModule (modul :: MetadataModule () ())
+compile :: String -> IO (Either String String)
+compile source = do
+  ifaces <- Prelude.interfaces
+  return $ case buildFromSource False ifaces source of
+    Left docs -> Left . unlines . List.intersperse "" $ map P.render docs
+    Right modul -> Right $ jsModule (modul :: MetadataModule () ())
 
 -- |This function extracts the module name of a given source program.
 moduleName :: String -> Maybe String


### PR DESCRIPTION
Load Prelude.interfaces in IO monad instead of using `unsafePerformIO`.

Is there a reason to use `unsafePerformIO` other than avoiding the IO annotation on a couple of functions?

This commit also prints errors when they occur loading interfaces to stderr instead of stdout.
