### PR TITLE
Fix deserialization of interfaces in Prelude

### DIFF
--- a/compiler/Metadata/Prelude.hs
+++ b/compiler/Metadata/Prelude.hs
@@ -47,9 +47,10 @@ safeReadDocs name =
                          , "    and specify your versions of Elm and your OS" ]
       exitFailure
 
-firstModuleInterface :: Interfaces -> Either String (String, ModuleInterface)
+firstModuleInterface :: [(String, ModuleInterface)] ->
+                        Either String (String, ModuleInterface)
 firstModuleInterface interfaces =
-    case Map.toList interfaces of
+    case interfaces of
       []      -> Left "No interfaces found in serialized Prelude!"
       iface:_ -> Right iface
 
@@ -69,10 +70,4 @@ readDocs filePath = do
       hPutStrLn stderr err
       exitFailure
 
-    -- Unwrapping the Right value here is safe since the whole above chain
-    -- returns a Right value. The toList/fromList is necessary because of a
-    -- problem with looking up keys in the Map after deserialization. Example
-    -- at https://gist.github.com/jsl/7294493.
-    -- TODO: try switching to Data.ByteString.Lazy.Char8
-    (Right ifaces, _) ->
-        return $ Map.fromList $ Map.toList ifaces
+    (Right ifaces, _) -> return $ Map.fromList ifaces


### PR DESCRIPTION
We previously had to fix a corrupt Map by changing it to a List and then back into a Map. It turns out we had to do this because the original data structure on disk wasn't a Map to begin with, but a List. It was previously assumed to be a Map by the compiler because the first function that it was passed to took a type of `Interfaces` which is a Map of interface definitions. Unfortunately this didn't cause a runtime error when Haskell found out that the structure wasn't
deserialized into a Map. Instead Haskell happily created a broken Map that couldn't find members some of the members that it contained (it could find somewhere around the first half of its members, but the second half it reported as missing when they were clearly present).

Changing the type of the first function that the deserialized structure is passed to from a Map (actually Interfaces which is a type of Map) to a List allows Haskell to infer the correct type to deserialize into and makes
everything work as expected.

Fixes #327.
