### PR TITLE
Remove unnecessary catch for file not found

### DIFF
--- a/compiler/Metadata/Prelude.hs
+++ b/compiler/Metadata/Prelude.hs
@@ -34,18 +34,7 @@ prelude = text ++ map (\n -> (n, Hiding [])) modules
 {-# NOINLINE interfaces #-}
 interfaces :: Interfaces
 interfaces =
-    unsafePerformIO (safeReadDocs =<< Path.getDataFileName "interfaces.data")
-
-safeReadDocs :: FilePath -> IO Interfaces
-safeReadDocs name =
-    E.catch (readDocs name) $ \err -> do
-      let _ = err :: IOError
-      putStrLn $ unlines [ "Error reading types for standard library!"
-                         , "    The file should be at " ++ name
-                         , "    If you are using a stable version of Elm,"
-                         , "    please report an issue at github.com/evancz/Elm"
-                         , "    and specify your versions of Elm and your OS" ]
-      exitFailure
+    unsafePerformIO (readDocs =<< Path.getDataFileName "interfaces.data")
 
 firstModuleInterface :: [(String, ModuleInterface)] ->
                         Either String (String, ModuleInterface)


### PR DESCRIPTION
We're already handling this error for both Prelude.interfaces and normal elmi file deserialization (by InterfaceSerialization.loadInterface which returns an Either), so I don't think we need this `catch` anymore. Let me know if you think something should be added or it should stay though.
