### PR TITLE
Remove instance of unsafePerformIO

### DIFF
--- a/compiler/Compiler.hs
+++ b/compiler/Compiler.hs
@@ -184,10 +184,14 @@ getRuntime flags =
 build :: Flags -> FilePath -> IO ()
 build flags rootFile = do
   let noPrelude = no_prelude flags
-  files <- if make flags then getSortedDependencies (src_dir flags) noPrelude rootFile
-                         else return [rootFile]
-  let ifaces = if noPrelude then Map.empty else Prelude.interfaces
-  (moduleName, interfaces) <- buildFiles flags (length files) ifaces "" files
+  builtIns <- if noPrelude then return Map.empty else Prelude.interfaces
+
+  files <- if make flags
+             then getSortedDependencies (src_dir flags) builtIns rootFile
+             else return [rootFile]
+
+  (moduleName, interfaces) <- buildFiles flags (length files) builtIns "" files
+
   js <- foldM appendToOutput BS.empty files
 
   (extension, code) <- case only_js flags of

--- a/compiler/Language/Elm.hs
+++ b/compiler/Language/Elm.hs
@@ -5,7 +5,14 @@
      <http://elm-lang.org/Documentation.elm>, and many interactive examples are
      available at <http://elm-lang.org/Examples.elm>
 -}
-module Language.Elm (compile, moduleName, runtime, docs) where
+module Language.Elm ( compile
+                    , interfaces
+                    , moduleName
+                    , runtime
+                    , docs
+                    , Interfaces
+                    , ModuleInterface )
+where
 
 import qualified Data.List as List
 import qualified Data.Map as Map
@@ -21,11 +28,14 @@ import Paths_Elm
 
 -- |This function compiles Elm code to JavaScript. It will return either
 --  an error message or the compiled JS code.
-compile :: String -> Either String String
-compile source =
-    case buildFromSource False Prelude.interfaces source of
-      Left docs -> Left . unlines . List.intersperse "" $ map P.render docs
-      Right modul -> Right $ jsModule (modul :: MetadataModule () ())
+compile :: Interfaces -> String -> Either String String
+compile ifaces source = do
+  case buildFromSource False ifaces source of
+    Left docs -> Left . unlines . List.intersperse "" $ map P.render docs
+    Right modul -> Right $ jsModule (modul :: MetadataModule () ())
+
+interfaces :: IO Interfaces
+interfaces = Prelude.interfaces
 
 -- |This function extracts the module name of a given source program.
 moduleName :: String -> Maybe String

--- a/compiler/Metadata/Prelude.hs
+++ b/compiler/Metadata/Prelude.hs
@@ -7,7 +7,6 @@ import System.Directory
 import System.Exit
 import System.FilePath
 import System.IO
-import System.IO.Unsafe (unsafePerformIO)
 import SourceSyntax.Module
 import qualified Data.Binary as Binary
 import qualified Data.ByteString.Lazy as BS
@@ -31,10 +30,8 @@ prelude = text ++ map (\n -> (n, Hiding [])) modules
     modules = [ "Basics", "Signal", "List", "Maybe", "Time", "Prelude"
               , "Graphics.Element", "Color", "Graphics.Collage" ]
 
-{-# NOINLINE interfaces #-}
-interfaces :: Interfaces
-interfaces =
-    unsafePerformIO (safeReadDocs =<< Path.getDataFileName "interfaces.data")
+interfaces :: IO Interfaces
+interfaces = safeReadDocs =<< Path.getDataFileName "interfaces.data"
 
 safeReadDocs :: FilePath -> IO Interfaces
 safeReadDocs name =


### PR DESCRIPTION
This commit exposes the Prelude.interfaces through the Elm module so that they can be more easily loaded in the IO monad of a calling program, and passed to pure compilation functions when needed. This allows us to be safe without loading the interfaces unnecessarily. It will also at some point allow for possibilities such as having the caller of the compile function define a different set of interfaces to build their program against if desired.

Opening a PR on elm-lang now as well so that it can build against this new interface. Please let me know in particular on this PR what you think about the function and types that I exposed on Language.Elm. Is it ok that they're on that module, or should we be putting them somewhere else?
