### PR TITLE
Fix various documentation broken links

### DIFF
--- a/libraries/Char.elm
+++ b/libraries/Char.elm
@@ -52,7 +52,7 @@ toLocaleLower = Native.Char.toLocaleLower
 
 type KeyCode = Int
 
-{-| Convert to unicode. Used with the [`Keyboard`](/docs/Keyboard.elm)
+{-| Convert to unicode. Used with the [`Keyboard`](/library/Keyboard.elm)
 library, which expects the input to be uppercase. -}
 toCode : Char -> KeyCode
 toCode = Native.Char.toCode

--- a/libraries/Http.elm
+++ b/libraries/Http.elm
@@ -1,7 +1,7 @@
 module Http where
 
 {-| A library for asynchronous HTTP requests. See the
-[WebSocket](http://elm-lang.org/docs/WebSocket.elm) library if
+[WebSocket](/library/WebSocket.elm) library if
 you have very strict latency requirements.
 
 # Sending Requests

--- a/libraries/Keyboard.elm
+++ b/libraries/Keyboard.elm
@@ -20,8 +20,8 @@ import Signal (Signal)
 import Native.Keyboard
 
 {-| Type alias to make it clearer what integers are supposed to represent
-in this library. Use [`Char.toCode`](docs/Char.elm#toCode) and
-[`Char.fromCode`](/docs/Char.elm#fromCode) to convert key codes to characters.
+in this library. Use [`Char.toCode`](library/Char.elm#toCode) and
+[`Char.fromCode`](/library/Char.elm#fromCode) to convert key codes to characters.
 Use the uppercase character with `toCode`.
 -}
 type KeyCode = Int

--- a/libraries/Signal.elm
+++ b/libraries/Signal.elm
@@ -10,7 +10,7 @@ past-dependence.
 
 Some useful functions for working with time (e.g. setting FPS) and combining
 signals and time (e.g.  delaying updates, getting timestamps) can be found in
-the [`Time`](/docs/Signal/Time.elm) library.
+the [`Time`](/library/Time.elm) library.
 
 # Combine
 @docs constant, lift, lift2, merge, merges, combine


### PR DESCRIPTION
Fix various broken links in documentation related to the switch from 'docs' to 'library'.
