### PR TITLE
Add check for duplicate constructors within the same unit

### DIFF
--- a/compiler/Transform/Check.hs
+++ b/compiler/Transform/Check.hs
@@ -32,11 +32,12 @@ getLets decls = defs : concatMap getSubLets defs
             Def pattern expr -> [ defs | Let defs _ <- universeBi expr ]
             TypeAnnotation _ _ -> []
 
-msg :: String
-msg  = "Syntax Error: There can only be one "
-
 dups :: Eq a => [a] -> [a]
 dups  = map head . filter ((>1) . length) . List.group
+
+dupErr :: String -> String -> String
+dupErr err x = 
+  "Syntax Error: There can only be one " ++ err ++ " '" ++ x ++ "'."
 
 duplicates :: [Def t v] -> [String]
 duplicates defs =
@@ -44,8 +45,8 @@ duplicates defs =
   where
     annotations = List.sort [ name | TypeAnnotation name _ <- defs ]
     definitions = List.sort $ concatMap Set.toList [ boundVars pattern | Def pattern _ <- defs ]
-    defMsg x = msg ++ "definition of '" ++ x ++ "'."
-    annMsg x = msg ++ "type annotation for '" ++ x ++ "'."
+    defMsg = dupErr "definition of"
+    annMsg = dupErr "type annotation for"
 
 duplicateConstructors :: [Declaration t v] -> [String]
 duplicateConstructors decls = 
@@ -54,8 +55,8 @@ duplicateConstructors decls =
     typeCtors = List.sort [ name | Datatype name _ _ <- decls ]
     dataCtors = List.sort . concat $
       [ map fst patterns | Datatype _ _ patterns <- decls ]
-    dataMsg x = msg ++ "definition of data constructor '" ++ x ++ "'."
-    typeMsg x = msg ++ "definition of type constructor '" ++ x ++ "'."
+    dataMsg = dupErr "definition of data constructor"
+    typeMsg = dupErr "definition of type constructor"
 
 badOrder :: [Def t v] -> [String]
 badOrder defs = go defs


### PR DESCRIPTION
This is a proposed fix for #380.  Comments welcome.  `msg` and `dup` look a bit silly sitting at top level ...

This is implemented in the "front-end" in a way similar to the checks for duplicate definitions and type synonyms, and, as with those, you currently don't get line numbers.

There's still a problem involving data and types imported from the Prelude or `open`ed modules.  I'll open a separate ticket for that.
