### PR TITLE
Update dependency information.

### DIFF
--- a/Elm.cabal
+++ b/Elm.cabal
@@ -80,7 +80,7 @@ Library
                        Type.Unify,
                        Paths_Elm
 
-  Build-depends:       base >=4.2 && <5,
+  Build-depends:       base >=4.6 && <5,
                        binary >= 0.6.4.0,
                        blaze-html == 0.5.* || == 0.6.*,
                        blaze-markup,
@@ -150,7 +150,7 @@ Executable elm
                        Type.Unify,
                        Paths_Elm
 
-  Build-depends:       base >=4.2 && <5,
+  Build-depends:       base >=4.6 && <5,
                        binary >= 0.6.4.0,
                        blaze-html == 0.5.* || == 0.6.*,
                        blaze-markup == 0.5.1.*,
@@ -193,7 +193,7 @@ Executable elm-doc
 
   Build-depends:       aeson,
                        aeson-pretty,
-                       base >=4.2 && <5,
+                       base >=4.6 && <5,
                        binary >= 0.6.4.0,
                        bytestring,
                        cmdargs,

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Learn about the Elm programming language at [elm-lang.org](http://elm-lang.org/)
 [these directions](http://justtesting.org/post/64947952690/the-glasgow-haskell-compiler-ghc-on-os-x-10-9)
 before continuing!
 
-Download the [Haskell Platform 2012.2.0.0 or later](http://hackage.haskell.org/platform/).
+Download the [Haskell Platform 2013.2.0.0 or later](http://hackage.haskell.org/platform/).
 Once the Haskell Platform is installed:
 
     cabal update


### PR DESCRIPTION
The use of `readMaybe` [here](https://github.com/evancz/Elm/blob/dev/compiler/Parse/Helpers.hs#L57) requires the latest minor version of base and thus the latest Haskell platform. This is a fix for what people were talking about [here](https://groups.google.com/forum/#!msg/elm-discuss/HXMZRmrQdzI/IOacFKKLIR4J).

The alternative to this fix is to not use `readMaybe`.

This is a copy of https://github.com/evancz/Elm/pull/374 so I can keep my dev branch up-to-date.
