### PR TITLE
Fix bug in parser

### DIFF
--- a/compiler/Parse/Helpers.hs
+++ b/compiler/Parse/Helpers.hs
@@ -274,7 +274,7 @@ ignoreUntil :: IParser a -> IParser (Maybe a)
 ignoreUntil end = go
     where
       ignore p = const () <$> p
-      filler = choice [ ignore str
+      filler = choice [ try (ignore chr) <|> ignore str
                       , ignore multiComment
                       , ignore (markdown (\_ _ -> mzero))
                       , ignore anyChar
@@ -337,3 +337,7 @@ str = choice [ quote >> dewindows <$> manyTill (backslashed <|> anyChar) quote
                        ('\n':rest)      -> '\n' : dewindows rest
                        ('\r':rest)      -> '\n' : dewindows rest
                        _                -> []
+
+chr :: IParser Char
+chr = betwixt '\'' '\'' (backslashed <|> satisfy (/='\''))
+      <?> "character"

--- a/compiler/Parse/Literal.hs
+++ b/compiler/Parse/Literal.hs
@@ -8,7 +8,7 @@ import Text.Parsec.Indent
 import Parse.Helpers
 import SourceSyntax.Literal
 
-literal = num <|> (Str <$> str) <|> chr
+literal = num <|> (Str <$> str) <|> (Chr <$> chr)
 
 num :: IParser Literal
 num = fmap toLit (preNum <?> "number")
@@ -21,7 +21,3 @@ num = fmap toLit (preNum <?> "number")
           minus = try $ do string "-"
                            lookAhead digit
                            return "-"
-
-chr :: IParser Literal
-chr = Chr <$> betwixt '\'' '\'' (backslashed <|> satisfy (/='\''))
-      <?> "character"

--- a/tests/good/QuotesAndComments.elm
+++ b/tests/good/QuotesAndComments.elm
@@ -1,0 +1,12 @@
+f x =
+ let
+  x' = x+1
+ in
+ x'
+
+g = '\"'
+
+n = '\''
+
+{- this is an {- embeded comment -} -}
+main = plainText "{-"


### PR DESCRIPTION
34913d5 broke the parser in the following case:

f = '\"'

This commit fixes that.
