### PR TITLE
Add more Maybe functions

### DIFF
--- a/libraries/Maybe.elm
+++ b/libraries/Maybe.elm
@@ -1,6 +1,6 @@
 module Maybe where
 
-{-| Represents an optional value. Maybe it is there, maybe it is not.
+{-| Represents an optional value. Maybe it is there, or maybe it is not.
 
 # Type and Constructors
 @docs Maybe, justIf
@@ -30,7 +30,7 @@ justIf : (a -> Bool) -> a -> Maybe a
 justIf p a = if p a then Just a else Nothing
 
 {-| Apply a function to the contents of a `Just`, or return the default when
-given `Nothing`.
+given `Nothing`. `maybe b f ma == just b (map f ma)`
 -}
 maybe : b -> (a -> b) -> Maybe a -> b
 maybe b f m = case m of


### PR DESCRIPTION
I'm not expecting immediate merger - I want to get this code out there and let the community discuss potential improvements. `justIf` is a higher-order version of `toMaybe` let-bound in #409.

I don't think anything in here is too controversial, as I left out (1) rewriting `maybe` in terms of `extract` and `map` (2) an unsafe extract function that crashes if given `Nothing`.
