### PR TITLE
Fix missing conversion of Elm strings to JS

### DIFF
--- a/libraries/Native/JavaScript.js
+++ b/libraries/Native/JavaScript.js
@@ -35,6 +35,7 @@ Elm.Native.JavaScript.make = function(elm) {
   function toJS(v) {
       var type = typeof v;
       if (type === 'number' || type === 'boolean') return v;
+      if (type === 'string') return v;
       if (type === 'object' && '_' in v) {
           var obj = {};
           for (var k in v) {


### PR DESCRIPTION
toJS would not convert strings and return null instead
related to issue #432 
