### PR TITLE
Add basic Travis CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: haskell
+ghc:
+  - 7.6

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 Learn about the Elm programming language at [elm-lang.org](http://elm-lang.org/).
 
-
 ## Install
 
 **Note for OS X 10.9 Maverics:** you must follow
@@ -49,3 +48,5 @@ Check it out [on Hackage](http://hackage.haskell.org/package/Elm) if you are int
 
 If you are stuck, email [the list](https://groups.google.com/forum/?fromgroups#!forum/elm-discuss)
 or ask a question in the [#Elm IRC channel](http://webchat.freenode.net/?channels=elm).
+
+[![Build Status](https://travis-ci.org/evancz/Elm.png)](https://travis-ci.org/evancz/Elm)


### PR DESCRIPTION
I added a basic Travis CI configuration to make the build status more transparent. I added a small logo to the bottom of the README with the status and a link to the build.

@evancz after merging this you'd have to go to https://travis-ci.org and enable the build for this project, just takes a couple of clicks. See http://about.travis-ci.org/docs/user/getting-started/.

I tested this on my own github account and the configuration worked (ie, it showed the same build errors on Travis that I'm experiencing locally).
