### PR TITLE
Hack to make imported names safe.

### DIFF
--- a/compiler/Generate/JavaScript.hs
+++ b/compiler/Generate/JavaScript.hs
@@ -12,7 +12,6 @@ import Generate.JavaScript.Helpers
 import qualified Generate.Cases as Case
 import qualified Generate.JavaScript.Ports as Port
 import qualified Generate.Markdown as MD
-import qualified Parse.Helpers as PHelp
 import qualified SourceSyntax.Helpers as Help
 import SourceSyntax.Literal
 import SourceSyntax.Pattern as Pattern
@@ -312,7 +311,7 @@ generate unsafeModule =
 
     jsImport modul = setup Nothing path ++ [ include ]
         where
-          path = PHelp.splitDots modul
+          path = Help.splitDots modul
           include = assign path $ dotSep ("Elm" : path ++ ["make"]) <| ref "_elm"
 
     setup namespace path = map create paths
@@ -352,7 +351,7 @@ binop span op e1 e2 =
     func | Help.isOp operator = BracketRef () (dotSep (init parts ++ ["_op"])) (string operator)
          | otherwise     = dotSep parts
         where
-          parts = PHelp.splitDots op
+          parts = Help.splitDots op
           operator = last parts
 
     opDict = Map.fromList (infixOps ++ specialOps)

--- a/compiler/Parse/Helpers.hs
+++ b/compiler/Parse/Helpers.hs
@@ -18,16 +18,6 @@ import SourceSyntax.Expression
 import SourceSyntax.PrettyPrint
 import SourceSyntax.Declaration (Assoc)
 
-splitDots :: String -> [String]
-splitDots = go []
-  where
-    go vars str =
-        case break (=='.') str of
-          (x,'.':rest) | Help.isOp x -> vars ++ [x ++ '.' : rest]
-                       | otherwise -> go (vars ++ [x]) rest
-          (x,[]) -> vars ++ [x]
-
-
 reserveds = [ "if", "then", "else"
             , "case", "of"
             , "let", "in"

--- a/compiler/SourceSyntax/Helpers.hs
+++ b/compiler/SourceSyntax/Helpers.hs
@@ -3,6 +3,15 @@ module SourceSyntax.Helpers where
 
 import qualified Data.Char as Char
 
+splitDots :: String -> [String]
+splitDots = go []
+  where
+    go vars str =
+        case break (=='.') str of
+          (x,_:rest) | isOp x -> vars ++ [x ++ '.' : rest]
+                     | otherwise -> go (vars ++ [x]) rest
+          (x,[]) -> vars ++ [x]
+
 brkt :: String -> String
 brkt s = "{ " ++ s ++ " }"
 

--- a/compiler/Transform/SafeNames.hs
+++ b/compiler/Transform/SafeNames.hs
@@ -5,15 +5,16 @@ import Control.Arrow           (first, (***))
 import Data.List               (intercalate)
 
 import qualified Data.Set as Set
-import qualified Parse.Helpers as PHelp
 
+import qualified Parse.Helpers        as PHelp
 import SourceSyntax.Expression
+import qualified SourceSyntax.Helpers as SHelp
 import SourceSyntax.Location
 import SourceSyntax.Module
 import SourceSyntax.Pattern
 
 var :: String -> String
-var = intercalate "." . map (dereserve . deprime) . PHelp.splitDots
+var = intercalate "." . map (dereserve . deprime) . SHelp.splitDots
   where
     deprime = map (\c -> if c == '\'' then '$' else c)
     dereserve x = case Set.member x PHelp.jsReserveds of


### PR DESCRIPTION
This fixes a bug where imported identifiers with reserved names were
not being changed during codegen:

Define a module exporting something like `int`/`float`/`elm` or the like

``` haskell
module Module where
int x = x + 1
```

and import it:

``` haskell
module Main where
import open Module
main = asText (int 1)
```

And get a runtime error:

``` haskell
Module.int is not a function
    Open the developer console for more details.
```

The fix is a bit of a hack, a nicer fix would be to have an identifier type, something like (but probably not exactly):

``` haskell
data IdTok = Op String | Alpha String
data Id = DottedId IdTok [IdTok]
```

to represent that an identifier can be a module import/record reference. This would enable the compiler to avoid the string munging that we see in the codegen and now IR transform phases and also prevent future bugs resulting from messing up string munging. I haven't done it yet bc that would touch a lot of code.
