### PR TITLE
README: Mark OS X workaround as for 10.8 as well as 10.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Learn about the Elm programming language at [elm-lang.org](http://elm-lang.org/)
 **Arch Linux** &mdash; follow [these directions](https://github.com/evancz/Elm/wiki/Installing-Elm#arch-linux) and then
 jump to the [My First Project](#my-first-project) section.
 <br/>
-**OS X 10.9** &mdash; follow
+**OS X 10.9 and 10.8** &mdash; follow
 [these directions](http://justtesting.org/post/64947952690/the-glasgow-haskell-compiler-ghc-on-os-x-10-9)
 before continuing with the platform agnostic directions below.
 


### PR DESCRIPTION
I lost a lot of time trying to build elm on OS X 10.8 because I assumed that the linked workaround for OS X 10.9 did not apply. Let's save future readers some time.
