### PR TITLE
Add Pretty instance to SourceSyntax.Module

### DIFF
--- a/compiler/SourceSyntax/Module.hs
+++ b/compiler/SourceSyntax/Module.hs
@@ -9,6 +9,7 @@ import Text.PrettyPrint as P
 import SourceSyntax.Expression (LExpr)
 import SourceSyntax.Declaration
 import SourceSyntax.Type
+import Data.List (intercalate)
 
 import qualified Elm.Internal.Version as Version
 import SourceSyntax.PrettyPrint
@@ -25,18 +26,18 @@ data ImportMethod = As String | Importing [String] | Hiding [String]
                     deriving (Eq, Ord, Show)
 
 instance (Pretty def ) => Pretty (Module def) where
-  pretty (Module names exports imports decs) = 
+  pretty (Module modNames exportList importList decs) = 
     let 
-        exportPret = case exports of 
+        exportPret = case exportList of 
                           [] -> P.text " "
-                          _ -> P.parens $ P.sep $ map P.text exports
+                          _ -> P.parens $ commaCat $ map P.text exportList
         
         decPret = P.sep $ map pretty decs
-        modName = P.text $ intercalate "." names
+        modName = P.text $ intercalate "." modNames
         modPret = (P.text "module" <+> modName <+> exportPret <+>  P.text "where")
         
         
-        importPret = P.sep $ map prettyImport imports
+        importPret = P.vcat $ map prettyImport importList
         
         prettyImport (name, method) = 
           case method of


### PR DESCRIPTION
No substantial changes, just adding a Pretty instance declaration for Modules in the syntax tree.

The following file serves as a basic test case. It can be parsed, pretty-printed, re-parsed, then re-pretty printed, meaning the output of the pretty printer is syntactically valid in this case.

```
module Foo (getType, getCtor)  where
import Y
import Json
import Dict as D

import open Transform2D

getType = \(Object d) -> case Dict.lookup "__type" d of
                          Just (Json.String t) -> t
getCtor = \(Object d) -> case Dict.lookup "__ctor" d of
                          Just (Json.String c) -> c
varNamed = \(Object d) n -> case Dict.lookup (show n) d of
                              Just val -> val
mapJson = \f (Array l) -> map f l
makeList = \(Array l) -> l
error = \s -> case True of False -> s
```
