### PR TITLE
Added Pretty instance for Module (3rd time's the charm)

### DIFF
--- a/compiler/SourceSyntax/Module.hs
+++ b/compiler/SourceSyntax/Module.hs
@@ -4,12 +4,16 @@ module SourceSyntax.Module where
 import Data.Binary
 import qualified Data.Map as Map
 import Control.Applicative ((<$>), (<*>))
+import Text.PrettyPrint as P
 
 import SourceSyntax.Expression (LExpr)
 import SourceSyntax.Declaration
 import SourceSyntax.Type
+import Data.List (intercalate)
 
 import qualified Elm.Internal.Version as Version
+import SourceSyntax.PrettyPrint
+
 
 data Module def =
     Module [String] Exports Imports [def]
@@ -21,6 +25,31 @@ type Imports = [(String, ImportMethod)]
 data ImportMethod = As String | Importing [String] | Hiding [String]
                     deriving (Eq, Ord, Show)
 
+instance (Pretty def ) => Pretty (Module def) where
+  pretty (Module modNames exportList importList decs) = 
+    let 
+        exportPret = case exportList of 
+                          [] -> P.text " "
+                          _ -> P.parens $ commaCat $ map P.text exportList
+        
+        decPret = P.sep $ map pretty decs
+        modName = P.text $ intercalate "." modNames
+        modPret = (P.text "module" <+> modName <+> exportPret <+>  P.text "where")
+        
+        
+        importPret = P.vcat $ map prettyImport importList
+        
+        prettyImport (name, method) = 
+          case method of
+               As s -> if name == s 
+                          then P.text $ "import " ++ name 
+                          else P.text $ "import " ++ name ++ " as " ++ s
+               Importing strs -> (P.text $ "import " ++ name ++ " ") <+> (commaCat $ map P.text strs)
+               Hiding [] -> (P.text $ "import open " ++ name ++ " ")
+               Hiding strs -> (P.text $ "import open " ++ name ++ " ") <+> (commaCat $ map P.text strs)
+
+    in P.sep [modPret, importPret, decPret]                    
+                    
 instance Binary ImportMethod where
     put method =
         let put' n info = putWord8 n >> put info in


### PR DESCRIPTION
No substantial changes, just adding a Pretty instance declaration for Modules in the syntax tree.

The following file serves as a basic test case. It can be parsed, pretty-printed, re-parsed, then re-pretty printed, meaning the output of the pretty printer is syntactically valid in this case.

```
module Foo (getType, getCtor)  where
import Y
import Json
import Dict as D

import open Transform2D

getType = \(Object d) -> case Dict.lookup "__type" d of
                          Just (Json.String t) -> t
getCtor = \(Object d) -> case Dict.lookup "__ctor" d of
                          Just (Json.String c) -> c
varNamed = \(Object d) n -> case Dict.lookup (show n) d of
                              Just val -> val
mapJson = \f (Array l) -> map f l
makeList = \(Array l) -> l
error = \s -> case True of False -> s
```

I had two garbage PRs preceding this, one because of a stupid mistake and one because Travis CI didn't like that I still had an old commit with the mistake, even when I'd fixed the new one. My apologies for the noise.
