### PR TITLE
Don't set innerHTML when contents didn't change

### DIFF
--- a/runtime/Render/Element.js
+++ b/runtime/Render/Element.js
@@ -209,7 +209,9 @@ function update(node, curr, next) {
     case "RawHtml":
         // only markdown blocks have guids, so this must be a text block
         if (nextE.guid === null) {
-            node.innerHTML = nextE.html;
+            if(currE.html.valueOf() !== nextE.html.valueOf()) {
+                node.innerHTML = nextE.html;
+            }
             break;
         }
         if (nextE.guid !== currE.guid) {


### PR DESCRIPTION
I am trying to understand the code of the current renderer and the technical aspect of the "renderer improvements project", applying some simple, small changes, finding ways to measure performance, finding current bottlenecks, etc.
With this change, the renderer doesn't reset the innerHTML when it has set the innerHTML of that node to that value before.

Example:
`main = beside (plainText "Hello World") . asText <~ count (fps 1)`

It doesn't replace the "Hello World" after this change, saving some time each frame.

Do you want to have a test framework in place for these kind of changes to test on regressions before applying them, or a good benchmark? If so, feel free to reject this pull request.
