### PR TITLE
Declare the trampoline variable before using it.

### DIFF
--- a/libraries/Native/Trampoline.js
+++ b/libraries/Native/Trampoline.js
@@ -5,6 +5,7 @@ Elm.Native.Trampoline.make = function(elm) {
     if (elm.Native.Trampoline.values) return elm.Native.Trampoline.values;
 
     // trampoline : Trampoline a -> a
+    var trampoline;
     trampoline = function(t) {
         var tramp = t;
         while(true) {


### PR DESCRIPTION
This makes the trampoline "module" work in strict mode which you are now using everywhere.
