### PR TITLE
Docs cosmetic: format some examples in String

### DIFF
--- a/libraries/String.elm
+++ b/libraries/String.elm
@@ -32,7 +32,11 @@ import Native.Show
 import Native.String
 import Maybe (Maybe)
 
-{-| Check if a string is empty `(isEmpty "" == True)` -}
+{-| Check if a string is empty.
+
+      isEmpty "" == True
+      isEmpty "the world" == False
+-}
 isEmpty : String -> Bool
 isEmpty = Native.String.isEmpty
 
@@ -64,7 +68,11 @@ append = Native.String.append
 concat : [String] -> String
 concat = Native.String.concat
 
-{-| Get the length of a string `(length "innumerable" == 11)` -}
+{-| Get the length of a string.
+
+      length "innumerable" == 11
+
+-}
 length : String -> Int
 length = Native.String.length
 
@@ -82,7 +90,10 @@ map = Native.String.map
 filter : (Char -> Bool) -> String -> String
 filter = Native.String.filter
 
-{-| Reverse a string. `(reverse "stressed" == "desserts")` -}
+{-| Reverse a string.
+
+      reverse "stressed" == "desserts"
+-}
 reverse : String -> String
 reverse = Native.String.reverse
 
@@ -118,7 +129,10 @@ split = Native.String.split
 join : String -> [String] -> String
 join = Native.String.join
 
-{-| Repeat a string N times `(repeat 3 "ha" == "hahaha")` -}
+{-| Repeat a string N times.
+
+      repeat 3 "ha" == "hahaha"
+-}
 repeat : Int -> String -> String
 repeat = Native.String.repeat
 


### PR DESCRIPTION
Moved the examples onto new line to match the rest of [the library](http://library.elm-lang.org/catalog/evancz-Elm/0.11/String). Contrast the four functions under Basics with everything else.
