### PR TITLE
Don't reset JS regexp lastIndex property for `contains` function

### DIFF
--- a/libraries/Native/Regex.js
+++ b/libraries/Native/Regex.js
@@ -20,7 +20,7 @@ Elm.Native.Regex.make = function(elm) {
     }
 
     function contains(re, string) {
-        return re.test(JS.fromString(string));
+        return JS.fromString(string).match(re).length > 0
     }
 
     function find(n, re, str) {


### PR DESCRIPTION
Prevent weirdness exhibited in https://gist.github.com/mg50/9579716.
