### PR TITLE
missing Native dependency (unchecked) causing runtime failure

### DIFF
--- a/libraries/JavaScript/Experimental.elm
+++ b/libraries/JavaScript/Experimental.elm
@@ -9,6 +9,7 @@ improve as we find its key failings.
 -}
 
 import Native.JavaScript
+import Native.Json
 import Json
 
 data RawObject = RawObject


### PR DESCRIPTION
This treats the symptom, not the cause. The compiler did not complain that we were using Native.Json without importing it. There was a runtime error because functions from Native.Json modules were never initialized. I'm going to skip opening a new issue since this isn't really public API stuff.
