### PR TITLE
Stopped event propagation in hoverables.

### DIFF
--- a/runtime/Render/Element.js
+++ b/runtime/Render/Element.js
@@ -64,14 +64,16 @@ function addHover(e, handler) {
     e.elm_hover_handler = handler;
     e.elm_hover_count = 0;
 
-    function over() {
+    function over(evt) {
         if (e.elm_hover_count++ > 0) return;
         e.elm_hover_handler(true);
+        evt.stopPropagation();
     }
     function out(evt) {
         if (e.contains(evt.toElement || evt.relatedTarget)) return;
         e.elm_hover_count = 0;
         e.elm_hover_handler(false);
+        evt.stopPropagation();
     }
     e.elm_hover_over = over;
     e.elm_hover_out = out;


### PR DESCRIPTION
To answer your final question in #559, yes. Hoverables seem to have the same behavior: http://share-elm.com/sprout/533d9161e4b0e548f3686519. This should fix it.
