### PR TITLE
Increase node stack size when running LibTests

### DIFF
--- a/tests/hs/LibTest.hs
+++ b/tests/hs/LibTest.hs
@@ -16,7 +16,7 @@ main = do
   setCurrentDirectory $ top</>"tests"</>"elm"
   runCmd $ concat [top</>"dist"</>"build"</>"elm"</>"elm --make --only-js --src-dir=" , top</>"automaton", " --src-dir=", top</>"IO", " --src-dir=", top</>"Elm-Test", " Test.elm"]
   runCmd $ unwords ["cat ", ioScript "prescript.js", Elm.runtime, "build"</>"Test.js", ioScript "handler.js", "> exe.js"]
-  exitWith =<< waitForProcess =<< (runCommand "node exe.js")
+  exitWith =<< waitForProcess =<< (runCommand "node --stack-size=32000 exe.js")
   where runCmd cmd = do
           putStrLn cmd
           exitCode <- waitForProcess =<< runCommand cmd


### PR DESCRIPTION
This will prevent errors like that in issue #587
