### PR TITLE
Add option to display location of elm_runtime.js

### DIFF
--- a/compiler/Build/Flags.hs
+++ b/compiler/Build/Flags.hs
@@ -15,6 +15,7 @@ data Flags = Flags
     , cache_dir :: FilePath
     , build_dir :: FilePath
     , src_dir :: [FilePath]
+    , show_runtime :: Bool
     }
     deriving (Data,Typeable,Show,Eq)
              
@@ -37,7 +38,9 @@ flags = Flags
   , src_dir = ["."] &= typFile
               &= help "Additional source directories besides project root. Searched when using --make"
   , print_types = False
-                  &= help "Print out infered types of top-level definitions."
+                  &= help "Print out inferred types of top-level definitions."
+  , show_runtime = False
+                   &= help "Print the absolute path to the default Elm runtime."
   } &= help "Compile Elm programs to HTML, CSS, and JavaScript."
     &= helpArg [explicit, name "help", name "h"]
     &= versionArg [explicit, name "version", name "v", summary (show Version.elmVersion)]

--- a/compiler/Compiler.hs
+++ b/compiler/Compiler.hs
@@ -1,12 +1,13 @@
 {-# OPTIONS_GHC -W #-}
 module Main where
 
-import Control.Monad (foldM)
+import Control.Monad (foldM, when)
 import qualified Data.Maybe as Maybe
 import Text.Blaze.Html.Renderer.String (renderHtml)
 import qualified Data.ByteString.Lazy.Char8 as BS
 import qualified System.Console.CmdArgs as CmdArgs
 import System.Directory
+import System.Exit (exitSuccess)
 import System.FilePath
 import GHC.Conc
 
@@ -24,7 +25,10 @@ main = do setNumCapabilities =<< getNumProcessors
 
 compileArgs :: Flag.Flags -> IO ()
 compileArgs flags =
-    case Flag.files flags of
+  do when (Flag.show_runtime flags) $ 
+         do putStrLn Path.runtime
+            exitSuccess
+     case Flag.files flags of
       [] -> putStrLn "Usage: elm [OPTIONS] [FILES]\nFor more help: elm --help"
       fs -> mapM_ (build flags) fs
 


### PR DESCRIPTION
Fixes my part of https://github.com/elm-lang/Elm/issues/492 .

I needed this in order to port the IO stuff to be pure node (no Haskell dependency unless you build elm/elm-get) using https://github.com/arsatiki/elmloader .

I'm not particularly attached to the `--show-runtime` name but I am in need of the functionality.
