### PR TITLE
Fixed bug where old String representation was used

### DIFF
--- a/libraries/Native/Signal/WebSocket.js
+++ b/libraries/Native/Signal/WebSocket.js
@@ -9,7 +9,7 @@ Elm.Native.WebSocket.make = function(elm) {
   var List = Elm.Native.List.make(elm);
 
   function open(url, outgoing) {
-    var incoming = Signal.constant(List.Nil);
+    var incoming = Signal.constant("");
     var ws = new WebSocket(url);
 
     var pending = [];


### PR DESCRIPTION
At least I think this bug was introduced with the big change in String representation. 
I found this bug using the [failing code example](https://groups.google.com/d/topic/elm-discuss/3xDhWg_CJYo/discussion) from the mailing-list.
