### PR TITLE
make the <a> tag the parent of the target to add hrefs to everything

### DIFF
--- a/runtime/Render/Element.js
+++ b/runtime/Render/Element.js
@@ -24,21 +24,24 @@ function setProps(elem, e) {
     if (props.href !== '') {
         var a = newElement('a');
         a.href = props.href;
-        a.style.width = '100%';
-        a.style.height = '100%';
-        a.style.top = 0;
-        a.style.left = 0;
         a.style.pointerEvents = 'auto';
         if (element.ctor === 'Image') {
+            a.style.width  = (width |0) + 'px';
+            a.style.height = (height|0) + 'px';
             a.style.position = 'relative';
             a.appendChild(e);
             e = a;
         } else {
+            a.style.width = '100%';
+            a.style.height = '100%';
+            a.style.top = 0;
+            a.style.left = 0;
             a.style.display = 'block';
             a.style.position = 'absolute';
             e.style.position = 'relative';
             e.appendChild(a);
         }
+        a.style.display = 'block';
     }
     if (props.hover.ctor !== '_Tuple0') {
         addHover(e, props.hover);
@@ -385,21 +388,24 @@ function updateProps(node, curr, next) {
         if (currP.href === '') {
             var a = newElement('a');
             a.href = props.href;
-            a.style.width = '100%';
-            a.style.height = '100%';
-            a.style.top = 0;
-            a.style.left = 0;
             a.style.pointerEvents = 'auto';
             if (element.ctor === 'Image') {
+                a.style.width  = (width |0) + 'px';
+                a.style.height = (height|0) + 'px';
                 a.style.position = 'relative';
                 a.appendChild(e);
                 e = a;
             } else {
+                a.style.width = '100%';
+                a.style.height = '100%';
+                a.style.top = 0;
+                a.style.left = 0;
                 a.style.display = 'block';
                 a.style.position = 'absolute';
                 e.style.position = 'relative';
                 e.appendChild(a);
             }
+            a.style.display = 'block';
         } else {
             node.lastNode.href = props.href;
         }


### PR DESCRIPTION
This is a fix for the following sprout:
http://www.share-elm.com/sprout/53b117d1e4b07afa6f982635

As first noticed by Do Bi.

I tried to keep this change pixel perfect but there may be a weird case I overlooked. See if you can break this.
