### PR TITLE
Add show to default imports

### DIFF
--- a/compiler/Generate/JavaScript.hs
+++ b/compiler/Generate/JavaScript.hs
@@ -37,6 +37,7 @@ internalImports name =
     , include "_L" "List" 
     , include "_A" "Array"
     , include "_E" "Error"
+    , include "_S" "Show"
     , varDecl Help.localModuleName (string name)
     ]
     where


### PR DESCRIPTION
Previously the repl used Native.Show but it was unavailable, giving a
TypeError.

Fixes https://github.com/elm-lang/Elm/issues/660.

To see why this is necessary, inputting

```
> 3
```

in the repl produces this JS at the end: 

``` javascript
Elm.Repl = Elm.Repl || {};
Elm.Repl.make = function (_elm) {
   "use strict";
   _elm.Repl = _elm.Repl || {};
   if (_elm.Repl.values)
   return _elm.Repl.values;
   var _op = {},
   _N = Elm.Native,
   _U = _N.Utils.make(_elm),
   _L = _N.List.make(_elm),
   _A = _N.Array.make(_elm),
   _E = _N.Error.make(_elm),
   $moduleName = "Repl";
   var tsol = {ctor: "_Tuple0"};
   var deltron3030 = 3;
   _elm.Repl.values = {_op: _op
                      ,deltron3030: deltron3030
                      ,tsol: tsol};
   return _elm.Repl.values;
};process.on('uncaughtException', function(err) {
  process.stderr.write(err.toString());
  process.exit(1);
});
var document = document || {};
var window = window || {};
var context = { inputs:[], addListener:function(){}, node:{} };
var repl = Elm.Repl.make(context);
if ('deltron3030' in repl)
  console.log(context.Native.Show.values.show(repl.deltron3030));
```

but context.Native.Show is undefined because it is never initialized in Elm.Repl.make. This change fixes that.
