### PR TITLE
bugfix: occasionaly restart would fail from an eventCounter mismatch

### DIFF
--- a/runtime/Debugger.js
+++ b/runtime/Debugger.js
@@ -226,6 +226,7 @@ function debuggerInit(debugModule, runtime, hotSwapState /* =undefined */) {
   }
 
   function restartProgram() {
+    pauseProgram();
     resetProgram(0);
     debugModule.watchTracker.clear();
     debugModule.tracePath.clearTraces();


### PR DESCRIPTION
I noticed a bug in https://github.com/elm-lang/Elm/pull/712 where restart wouldn't work the first time it was called. It would work the second time, though. Mario would go back to his starting position but the FPS timers weren't firing. The assert:

```
assert(tracePositions[id].length === eventCounter,
             "We don't have a 1-1 mapping of trace positions to events");
```

was not true, off-by-one.

By pausing before restarting we prevent events from going halfway through the pipeline and screwing with this assert, and code that follows. It also makes sense that before restarting we should pause. When we click restart, we don't care about any more events flowing through the program. We should stop them from mutating the debugger state by pausing.
