### PR TITLE
typeof checked against a non-standard string, best not to throw an error at all

### DIFF
--- a/runtime/Init.js
+++ b/runtime/Init.js
@@ -45,9 +45,6 @@ function init(display, container, module, ports, moduleToReplace) {
     };
 
     var addDelay = function(d) {
-      if (typeof d !== "number") {
-        throw "addDelay must take a number (preferably an int), not: " + d
-      }
       inducedDelay += d;
       return inducedDelay;
     }


### PR DESCRIPTION
This was a pretty dumb thing for me to commit. It's bad practice to check typeof against anything besides "function" and "object". Let's just get this out of there.
