### PR TITLE
Debugger combined call

### DIFF
--- a/runtime/Debugger.js
+++ b/runtime/Debugger.js
@@ -20,10 +20,15 @@ Elm.debuggerAttach = function(module, hotSwapState /* =undefined */) {
   };
 };
 
-var filename = "";
 Elm.debugFullscreen = function(module, moduleFile, hotSwapState /* =undefined */) {
-  filename = moduleFile;
-  var debuggedModule = Elm.debuggerAttach(module, hotSwapState);
+  var debuggedModule = {
+    make: function(runtime) {
+      var wrappedModule = debugModule(module, runtime);
+      Elm.Debugger = debuggerInit(wrappedModule, runtime, hotSwapState, moduleFile);
+      dispatchElmDebuggerInit();
+      return wrappedModule.debuggedModule;
+    }
+  }
   return Elm.fullscreen(debuggedModule);
 };
 
@@ -222,7 +227,8 @@ function debugModule(module, runtime) {
   };
 }
 
-function debuggerInit(debugModule, runtime, hotSwapState /* =undefined */) {
+function debuggerInit(debugModule, runtime, hotSwapState /* =undefined */, moduleFile /* =undefined */) {
+  var filename = moduleFile || "";
   var currentEventIndex = 0;
 
   function resetProgram(position) {


### PR DESCRIPTION
I've created `Elm.debugFullscreen()` which does not take ports, since they're unsupported with debugging. It stores the filename it receives in the `Elm.Debugger` object for the debugging interface to retrieve.
Creating an object like `Debug` for `Debug.fullscreen()` seems like it would be an intrusive change.

Motivated by https://github.com/elm-lang/elm-server/pull/12.
