### PR TITLE
Runtime seems like the most appropriate place for eventCounter

### DIFF
--- a/runtime/Debugger.js
+++ b/runtime/Debugger.js
@@ -44,8 +44,8 @@ function debugModule(module, runtime) {
   var watchTracker = Elm.Native.Debug.make(runtime).watchTracker;
   var pauseTime = 0;
   var eventsUntilSnapshot = EVENTS_PER_SAVE;
-  runtime.DebugStatus = runtime.DebugStatus || {};
-  runtime.DebugStatus.eventCounter = runtime.DebugStatus.eventCounter || 0;
+  runtime.debuggerStatus = runtime.debuggerStatus || {};
+  runtime.debuggerStatus.eventCounter = runtime.debuggerStatus.eventCounter || 0;
 
   // runtime is the prototype of wrappedRuntime
   // so we can access all runtime properties too
@@ -112,7 +112,7 @@ function debugModule(module, runtime) {
   function recordEvent(id, v, timestep) {
     watchTracker.pushFrame();
     recordedEvents.push({ id:id, value:v, timestep:timestep });
-    runtime.DebugStatus.eventCounter += 1;
+    runtime.debuggerStatus.eventCounter += 1;
   }
 
   function clearAsyncCallbacks() {
@@ -125,7 +125,7 @@ function debugModule(module, runtime) {
 
   function clearRecordedEvents() {
     recordedEvents = [];
-    runtime.DebugStatus.eventCounter = 0;
+    runtime.debuggerStatus.eventCounter = 0;
   }
 
   function getRecordedEventsLength() {
@@ -183,7 +183,7 @@ function debugModule(module, runtime) {
       snapshots = snapshots.slice(0, lastSnapshotPosition + 1);
       recordedEvents = recordedEvents.slice(0, position);
       tracePath.clearTracesAfter(position);
-      runtime.DebugStatus.eventCounter = position;
+      runtime.debuggerStatus.eventCounter = position;
       executeCallbacks(asyncCallbacks, false);
     }
     tracePath.startRecording();
@@ -321,14 +321,14 @@ function debuggerInit(debugModule, runtime, hotSwapState /* =undefined */) {
     debugModule.setPaused();
     debugModule.loadRecordedEvents(hotSwapState.recordedEvents);
     var index = getMaxSteps();
-    runtime.DebugStatus.eventCounter = 0;
+    runtime.debuggerStatus.eventCounter = 0;
     debugModule.tracePath.clearTraces();
 
     // draw new trace path
     debugModule.tracePath.startRecording();
     while(currentEventIndex < index) {
       var nextEvent = debugModule.getRecordedEventAt(currentEventIndex);
-      runtime.DebugStatus.eventCounter += 1;
+      runtime.debuggerStatus.eventCounter += 1;
       runtime.notify(nextEvent.id, nextEvent.value, nextEvent.timestep);
       debugModule.snapshotOnCheckpoint();
       currentEventIndex += 1;
@@ -413,14 +413,14 @@ function tracePathInit(runtime, signalGraphMain) {
       else {
         tracePositions[id] = [pos];
       }
-      if (tracePositions[id].length < runtime.DebugStatus.eventCounter) {
-        var padCount = runtime.DebugStatus.eventCounter - tracePositions[id].length;
+      if (tracePositions[id].length < runtime.debuggerStatus.eventCounter) {
+        var padCount = runtime.debuggerStatus.eventCounter - tracePositions[id].length;
         var lastTracePosition = tracePositions[id][tracePositions[id].length - 1];
         for (var i = padCount; i--;) {
           tracePositions[id].push(lastTracePosition)
         }
       }
-      assert(tracePositions[id].length === runtime.DebugStatus.eventCounter,
+      assert(tracePositions[id].length === runtime.debuggerStatus.eventCounter,
              "We don't have a 1-1 mapping of trace positions to events");
     }
   }


### PR DESCRIPTION
Fix suggestion for https://github.com/elm-lang/Elm/issues/702. The global eventCounter gets put in `elm.DebugStatus.eventCounter`. Putting it in `elm.eventCounter` seems like the value is put in a public spot for any native developers. Instead it seems more appropriate to put it in an object that identifies what the value is for.
