### PR TITLE
Implement new rules for build/cache file locations.

### DIFF
--- a/Elm.cabal
+++ b/Elm.cabal
@@ -50,6 +50,7 @@ Library
                        AST.Module,
                        AST.Pattern,
                        AST.PrettyPrint,
+                       AST.ProgramHeader,
                        AST.Type,
                        AST.Variable,
                        Generate.JavaScript,
@@ -98,6 +99,7 @@ Library
                        Build.Interface,
                        Build.Print,
                        Build.Source,
+                       Build.SrcFile,
                        Build.Utils,
                        Paths_Elm
 
@@ -141,6 +143,7 @@ Executable elm
                        AST.Module,
                        AST.Pattern,
                        AST.PrettyPrint,
+                       AST.ProgramHeader,
                        AST.Type,
                        AST.Variable,
                        Generate.JavaScript,
@@ -189,6 +192,7 @@ Executable elm
                        Build.Interface,
                        Build.Print,
                        Build.Source,
+                       Build.SrcFile,
                        Build.Utils,
                        Paths_Elm
 
@@ -228,6 +232,7 @@ Executable elm-doc
                        AST.Module,
                        AST.Pattern,
                        AST.PrettyPrint,
+                       AST.ProgramHeader,
                        AST.Type,
                        AST.Variable,
                        Parse.Binop,

--- a/compiler/AST/ProgramHeader.hs
+++ b/compiler/AST/ProgramHeader.hs
@@ -1,0 +1,25 @@
+module AST.ProgramHeader where
+
+import qualified Data.List as List
+import System.FilePath ((</>))
+
+import qualified AST.Module as M
+import qualified AST.Variable as Var
+import qualified Elm.Internal.Name as Package
+
+type ModuleName = [String] -- | Invariant: Nonempty
+type ModuleId   = (Maybe Package.Name, ModuleName)
+
+toName :: ModuleName -> String
+toName = List.intercalate "."
+
+modulePath :: ModuleName -> FilePath
+modulePath = foldr1 (</>) 
+
+data ProgramHeader = ProgramHeader
+    { _names :: ModuleName
+    , _exports :: Var.Listing Var.Value
+    , _docComment :: Maybe String
+    , _imports :: [(ModuleName, M.ImportMethod)]
+    } deriving (Show)
+

--- a/compiler/Build/Dependencies.hs
+++ b/compiler/Build/Dependencies.hs
@@ -1,17 +1,20 @@
 {-# OPTIONS_GHC -W #-}
-module Build.Dependencies (Recipe(..), getBuildRecipe, readDeps) where
+module Build.Dependencies (Recipe(..), getBuildRecipe) where
 
+import Control.Applicative ((<$>), (<*>))
 import Control.Monad.Error
 import qualified Control.Monad.State as State
 import qualified Data.Graph as Graph
-import qualified Data.List as List
 import qualified Data.Map as Map
 import qualified Data.Set as Set
 import System.Directory
 import System.FilePath as FP
 
 import qualified AST.Module as Module
-import qualified Parse.Parse as Parse
+import AST.ProgramHeader
+import qualified AST.ProgramHeader as ProgramHeader
+import Build.SrcFile
+import qualified Build.SrcFile as SrcFile
 import qualified Elm.Internal.Paths as Path
 import qualified Elm.Internal.Dependencies as Deps (withNative)
 import qualified Elm.Internal.Libraries as L (withVersions)
@@ -19,37 +22,52 @@ import qualified Elm.Internal.Name as N
 import qualified Elm.Internal.Version as V
 
 data Recipe = Recipe
-    { _elmFiles :: [FilePath]
-    , _jsFiles :: [FilePath]
+    { _elmFiles :: [ResolvedSrcFile]
+    , _jsFiles  :: [FilePath]
     }
 
-getBuildRecipe :: [FilePath] -> Module.Interfaces -> FilePath -> ErrorT String IO Recipe
-getBuildRecipe srcDirs builtIns root =
+data Dir = SrcDir  FilePath
+         | Package N.Name FilePath
+         deriving Show
+
+dirPath :: Dir -> FilePath
+dirPath (SrcDir path)    = path
+dirPath (Package _ path) = path
+
+packageName :: Dir -> Maybe N.Name
+packageName (Package n _) = Just n
+packageName _             = Nothing
+
+getBuildRecipe :: Bool -> [FilePath] -> Module.Interfaces -> UnresolvedSrcFile -> ErrorT String IO Recipe
+getBuildRecipe isMake srcDirs builtIns srcFile =
   do directories <- getDependencies
-     jsFiles <- nativeFiles ("." : directories)
-     let allSrcDirs = srcDirs ++ directories
-     nodes <- collectDependencies allSrcDirs builtIns root
-     elmFiles <- sortElmFiles nodes
-     return (Recipe elmFiles jsFiles)
+     let allSrcDirs = (map SrcDir srcDirs) ++ (map (uncurry Package) directories)
+     if not isMake
+       then (\src -> Recipe [src] []) <$> resolveSrcFile allSrcDirs srcFile
+       else do
+       jsFiles  <- nativeFiles ("." : (map snd directories))
+       nodes    <- collectDependencies allSrcDirs builtIns srcFile
+       elmFiles <- sortElmFiles nodes
+       return (Recipe elmFiles jsFiles)
 
 -- | Based on the projects elm_dependencies.json, find all of the paths and
 --   dependency information we might need.
-getDependencies :: ErrorT String IO [FilePath]
+getDependencies :: ErrorT String IO [(N.Name, FilePath)]
 getDependencies =
     do exists <- liftIO $ doesFileExist Path.librariesFile
        if not exists then return [] else getPaths
     where
-      getPaths :: ErrorT String IO [FilePath]
+      getPaths :: ErrorT String IO [(N.Name, FilePath)]
       getPaths =
         L.withVersions Path.librariesFile $ \vers ->
             mapM getPath vers
 
-      getPath :: (N.Name, V.Version) -> ErrorT String IO FilePath
+      getPath :: (N.Name, V.Version) -> ErrorT String IO (N.Name, FilePath)
       getPath (name,version) = do
         let path = Path.dependencyDirectory </> N.toFilePath name </> show version
         exists <- liftIO $ doesDirectoryExist path
         if exists
-          then return path
+          then return (name, path)
           else throwError (notFound name version)
 
       -- TODO: This message should be changed
@@ -84,10 +102,10 @@ split moduleName = go [] moduleName
           (path, _:rest) -> go (paths ++ [path]) rest
           (path, [])     -> paths ++ [path]
 
-type DependencyNode = (FilePath, String, [String])
+type DependencyNode = (ResolvedSrcFile, ModuleId, [ModuleId])
 
-sortElmFiles :: [DependencyNode] -> ErrorT String IO [FilePath]
-sortElmFiles depends =
+sortElmFiles :: [DependencyNode] -> ErrorT String IO [ResolvedSrcFile]
+sortElmFiles depends = do
     if null mistakes
       then return (concat sccs)
       else throwError $ msg ++ unlines (map show mistakes)
@@ -97,49 +115,67 @@ sortElmFiles depends =
     mistakes = filter (\scc -> length scc > 1) sccs
     msg = "A cyclical module dependency or was detected in:\n"
 
-collectDependencies :: [FilePath] -> Module.Interfaces -> FilePath
+collectDependencies :: [Dir] -> Module.Interfaces -> UnresolvedSrcFile
                     -> ErrorT String IO [DependencyNode]
-collectDependencies srcDirs rawBuiltIns filePath =
-    State.evalStateT (go Nothing filePath) Set.empty
+collectDependencies srcDirs rawBuiltIns srcFile =
+    State.evalStateT (go srcFile) Set.empty
   where
-    builtIns :: Set.Set String
-    builtIns = Set.fromList $ Map.keys rawBuiltIns
+    builtIns :: Set.Set (Maybe N.Name, ModuleName)
+    builtIns = Set.fromList . map ((,) Nothing . split) $ Map.keys rawBuiltIns
 
-    go :: Maybe String -> FilePath -> State.StateT (Set.Set String) (ErrorT String IO) [DependencyNode]
-    go parentModuleName filePath = do
-      filePath' <- lift $ findSrcFile parentModuleName srcDirs filePath
-      (moduleName, deps) <- lift $ readDeps filePath'
+    nativeOrBuiltIn = (||) <$> isNativeModule <*> isBuiltInModule
+    isBuiltInModule = flip Map.member rawBuiltIns . ProgramHeader.toName
+
+    go :: UnresolvedSrcFile -> State.StateT (Set.Set ModuleId) (ErrorT String IO) [DependencyNode]
+    go srcFile = do
+      let deps     = filter (not . nativeOrBuiltIn) . getDeps $ srcFile
+          moduleId = SrcFile.moduleId srcFile
+          validSrcDirs = case SrcFile.pkg srcFile of
+            Nothing -> srcDirs
+            n       -> filter ((==) n . packageName) srcDirs
+      depSrcs <- lift $ forM deps (findSrcFile moduleId validSrcDirs)
       seen <- State.get
-      let realDeps = Set.difference (Set.fromList deps) builtIns
-          newDeps = Set.difference (Set.filter (not . isNative) realDeps) seen
-      State.put (Set.insert moduleName (Set.union newDeps seen))
-      rest <- mapM (go (Just moduleName) . toFilePath) (Set.toList newDeps)
-      return ((makeRelative "." filePath', moduleName, Set.toList realDeps) : concat rest)
 
-readDeps :: FilePath -> ErrorT String IO (String, [String])
-readDeps path = do
-  txt <- lift $ readFile path
-  case Parse.dependencies txt of
-    Right o  -> return o
-    Left err -> throwError $ msg ++ show err
-      where msg = "Error resolving dependencies in " ++ path ++ ":\n"
+      let depIds    = Set.fromList . map (\(_,id,_) -> id) $ depSrcs
+          newDeps   = Set.difference depIds seen
+          isNew (_, key, _) = Set.member key newDeps
+      State.put (Set.insert moduleId (Set.union newDeps seen))
 
-findSrcFile :: Maybe String -> [FilePath] -> FilePath -> ErrorT String IO FilePath
-findSrcFile parentModuleName dirs path =
+      let resolved = SrcFile.resolve srcFile . map (\(_,ids,_) -> ids) $ depSrcs
+      rest <- mapM (go . (\(x,_,_) -> x)) . filter isNew $ depSrcs
+      return ((resolved, moduleId, Set.toList depIds) : concat rest)
+    
+
+resolveSrcFile :: [Dir] -> UnresolvedSrcFile -> ErrorT String IO ResolvedSrcFile
+resolveSrcFile dirs oSrcFile =
+  SrcFile.resolve oSrcFile . map (\(_,mid,_) -> mid) <$> forM deps (findSrcFile srcId dirs)
+  where deps  = SrcFile.getDeps oSrcFile
+        srcId = (Nothing, SrcFile.moduleName oSrcFile)
+  
+
+findSrcFile :: ModuleId -> [Dir] -> ModuleName -> ErrorT String IO (UnresolvedSrcFile, ModuleId, [ModuleId])
+findSrcFile (parentPkg, parentName) dirs name =
     foldr tryDir notFound dirs
   where
     tryDir dir next = do
-      let path' = dir </> path
+      let path' = dirPath dir </> path
       exists <- liftIO $ doesFileExist path'
-      if exists
-        then return path'
-        else next
+      if not exists
+        then next
+        else do
+        let pkg = packageName dir
+        src <- SrcFile.load pkg path'
+        let header  = SrcFile.header src
+            imports = ProgramHeader._imports $ header
+            withPkg = (,) pkg
+        return (src, (pkg, ProgramHeader._names header), map (withPkg . fst) imports)
 
-    parentModuleName' =
-        case parentModuleName of
-          Just name -> "module '" ++ name ++ "'"
-          Nothing -> "the main module"
+    parentModuleName' = "module '" ++ (ProgramHeader.toName $ parentName) ++ "'" ++ mayPkg
+    mayPkg = case parentPkg of
+      Nothing -> ""
+      Just n  -> "in package " ++ show n
 
+    path = ProgramHeader.modulePath name <.> "elm"
     notFound = throwError $ unlines
         [ "When finding the imports declared in " ++ parentModuleName' ++ ", could not find file: " ++ path
         , "    If you created this module, but it is in a subdirectory that does not"
@@ -149,12 +185,6 @@ findSrcFile parentModuleName dirs path =
         , "    as a dependency in your project's " ++ Path.dependencyFile ++ " file."
         ]
 
-isNative :: String -> Bool
-isNative name = List.isPrefixOf "Native." name
-
-toFilePath :: String -> FilePath
-toFilePath name = map swapDots name ++ ext
-  where
-    swapDots '.' = '/'
-    swapDots  c  =  c
-    ext = if isNative name then ".js" else ".elm"
+isNativeModule :: [String] -> Bool
+isNativeModule ("Native":_) = True
+isNativeModule _            = False

--- a/compiler/Build/File.hs
+++ b/compiler/Build/File.hs
@@ -2,7 +2,6 @@
 module Build.File (build) where
 
 import Control.Applicative ((<$>))
-import Control.Monad.Error (runErrorT)
 import Control.Monad.RWS.Strict
 import System.Directory
 import System.Exit
@@ -15,47 +14,53 @@ import qualified Data.Maybe as Maybe
 import qualified Data.Map as Map
 import qualified Data.ByteString.Lazy as L
 
-import qualified Build.Dependencies as Deps
+import AST.Helpers (splitDots)
+import AST.ProgramHeader (ModuleId)
+import qualified AST.ProgramHeader as ProgramHeader
 import qualified Build.Flags as Flag
 import qualified Build.Interface as Interface
 import qualified Build.Print as Print
 import qualified Build.Source as Source
+import Build.SrcFile (ResolvedSrcFile)
+import qualified Build.SrcFile as SrcFile
 import qualified Build.Utils as Utils
 import qualified Generate.JavaScript as JS
-import qualified Parse.Module as Parser
 import qualified AST.Module as Module
 
 -- Reader: Runtime flags, always accessible
 -- Writer: Remember the last module to be accessed
 -- State:  Build up a map of the module interfaces
-type BuildT m a = RWST Flag.Flags (Last String) BInterfaces m a
+type BuildT m a = RWST Flag.Flags (Last ModuleId) BInterfaces m a
 type Build a = BuildT IO a
 
 -- Interfaces, remembering if something was recompiled
-type BInterfaces = Map.Map String (Bool, Module.Interface)
+type BInterfaces = Map.Map ModuleId (Bool, Module.Interface)
 
 evalBuild :: Flag.Flags -> Module.Interfaces -> Build ()
-          -> IO (Map.Map String Module.Interface, Maybe String)
-evalBuild flags interfaces build =
-  do (ifaces, moduleNames) <- execRWST build flags (fmap notUpdated interfaces)
+          -> IO (Map.Map ModuleId Module.Interface, Maybe ModuleId)
+evalBuild flags builtins build =
+  do (ifaces, moduleNames) <- execRWST build flags (toBInterface builtins)
      return (fmap snd ifaces, getLast moduleNames)
   where
+    toBInterface     = fmap notUpdated . Map.mapKeys builtInModuleId
+    builtInModuleId name = (Nothing, splitDots name)
     notUpdated iface = (False, iface)
 
 -- | Builds a list of files, returning the moduleName of the last one.
 --   Returns \"\" if the list is empty
-build :: Flag.Flags -> Module.Interfaces -> [FilePath] -> IO String
-build flags interfaces files =
-  do (ifaces, topName) <- evalBuild flags interfaces (buildAll files)
+build :: Flag.Flags -> Module.Interfaces -> [ResolvedSrcFile] -> IO String
+build flags builtins files =
+  do (ifaces, topName) <- evalBuild flags builtins (buildAll files)
      let removeTopName = Maybe.maybe id Map.delete topName
      mapM_ (checkPorts topName) (Map.toList $ removeTopName ifaces)
-     return $ Maybe.fromMaybe "" topName
+     return $ Maybe.maybe "" (ProgramHeader.toName . snd) topName
   where
-    checkPorts topName (name,iface)
+    checkPorts topName ((_, names),iface)
         | null ports = return ()
         | otherwise  = Print.failure msg
         where
           ports = Module.iPorts iface
+          name  = ProgramHeader.toName names
           msg = concat
             [ "Port Error: ports may only appear in the main module, but\n"
             , "    sub-module ", name, " declares the following port"
@@ -63,46 +68,43 @@ build flags interfaces files =
             , List.intercalate ", " ports
             , case topName of
                 Nothing -> ""
-                Just tname -> "\n    All ports must appear in module " ++ tname
+                Just (_, tname) -> "\n    All ports must appear in module " ++ ProgramHeader.toName tname
             ]
 
-buildAll :: [FilePath] -> Build ()
+buildAll :: [ResolvedSrcFile] -> Build ()
 buildAll fs = mapM_ (uncurry build1) (zip [1..] fs)
-  where build1 :: Integer -> FilePath -> Build ()
-        build1 num fname = do
-          shouldCompile <- shouldBeCompiled fname
+  where build1 :: Integer -> ResolvedSrcFile -> Build ()
+        build1 num srcFile = do
+          shouldCompile <- shouldBeCompiled srcFile
           if shouldCompile
-            then compile number fname
-            else retrieve fname
+            then compile number srcFile
+            else retrieve srcFile
 
           where number = join ["[", show num, " of ", show total, "]"]
 
         total = length fs
 
-shouldBeCompiled :: FilePath -> Build Bool
-shouldBeCompiled filePath = do
+shouldBeCompiled :: ResolvedSrcFile -> Build Bool
+shouldBeCompiled srcFile = do
   flags <- ask
-  let alreadyCompiled = liftIO $ do
-        existsi <- doesFileExist (Utils.elmi flags filePath)
-        existso <- doesFileExist (Utils.elmo flags filePath)
+  let elmi = Utils.elmi flags srcFile
+      elmo = Utils.elmo flags srcFile
+
+      alreadyCompiled = liftIO $ do
+        existsi <- doesFileExist elmi
+        existso <- doesFileExist elmo
         return $ existsi && existso
 
       outDated = liftIO $ do
-        tsrc <- getModificationTime filePath
-        tint <- getModificationTime (Utils.elmo flags filePath)
+        tsrc <- getModificationTime (SrcFile.path srcFile)
+        tint <- getModificationTime elmo
         return (tsrc > tint)
 
-      dependenciesUpdated = do
-        eDeps <- liftIO . runErrorT $ Deps.readDeps filePath
-        case eDeps of
-          -- Should never actually reach here
-          Left  err       -> liftIO $ Print.failure err
-          Right (_, deps) -> anyM wasCompiled deps
-        
-  
+      dependenciesUpdated = anyM wasCompiled (SrcFile.resolvedDeps srcFile)
+
     in (not <$> alreadyCompiled) `orM` outDated `orM` dependenciesUpdated
 
-wasCompiled :: String -> Build Bool
+wasCompiled :: ModuleId -> Build Bool
 wasCompiled modul = maybe False fst . Map.lookup modul <$> get
   
 -- Short-circuiting monadic (||)
@@ -116,31 +118,33 @@ orM m1 m2 = do b1 <- m1
 anyM :: (Monad m) => (a -> m Bool) -> [a] -> m Bool
 anyM f = foldr (orM . f) (return False)
 
-retrieve :: FilePath -> Build ()
-retrieve filePath = do
+retrieve :: ResolvedSrcFile -> Build ()
+retrieve srcFile = do
   flags <- ask
-  iface <- liftIO $ Interface.load (Utils.elmi flags filePath)
-  case Interface.isValid filePath iface of
-    Right (name, interface) ->
+  iface <- liftIO $ Interface.load (Utils.elmi flags srcFile)
+  case Interface.isValid (SrcFile.path srcFile) iface of
+    Right (_, interface) ->
       do liftIO $ when (Flag.print_types flags) (Print.types (Module.iTypes interface))
-         update name interface False
+         update mId interface False
 
     Left err -> liftIO $ Print.failure err
 
-compile :: String -> FilePath -> Build ()
-compile number filePath =
+  where mId = SrcFile.moduleId srcFile
+
+compile :: String -> ResolvedSrcFile -> Build ()
+compile number srcFile =
   do flags      <- ask
      binterfaces <- get
      source <- liftIO $ readFile filePath
-     let interfaces = snd <$> binterfaces
-         name = getName source
+     let interfaces = toInterfaces binterfaces
      liftIO $ do
        printStatus name
        createDirectoryIfMissing True (Flag.cache_dir flags)
        createDirectoryIfMissing True (Flag.build_dir flags)
 
      canonicalModule <- 
-       liftIO $ case Source.build (Flag.no_prelude flags) interfaces source of
+       liftIO $ do
+         case Source.build (Flag.no_prelude flags) interfaces source of
            Right modul -> return modul
            Left errors -> do Print.errors errors
                              exitFailure
@@ -150,13 +154,15 @@ compile number filePath =
   
      let newInters = Module.toInterface canonicalModule
      generateCache name newInters canonicalModule
-     update name newInters True
+     update (SrcFile.moduleId srcFile) newInters True
 
   where
-    getName source = case Parser.getModuleName source of
-                       Just n -> n
-                       Nothing -> "Main"
+    name     = ProgramHeader.toName . SrcFile.moduleName $ srcFile
+    filePath = SrcFile.path srcFile
 
+    toInterfaces :: BInterfaces -> Module.Interfaces
+    toInterfaces = Map.mapKeys (ProgramHeader.toName . snd) . fmap snd
+    
     printStatus name =
         hPutStrLn stdout $ concat [ number, " Compiling ", name
                                   , replicate (max 1 (20 - length name)) ' '
@@ -164,13 +170,15 @@ compile number filePath =
 
     generateCache name interfs canonicalModule = do
       flags <- ask
+      let elmi = Utils.elmi flags srcFile
+          elmo = Utils.elmo flags srcFile
       liftIO $ do
-        createDirectoryIfMissing True . dropFileName $ Utils.elmi flags filePath
-        writeFile (Utils.elmo flags filePath) (JS.generate canonicalModule)
-        withBinaryFile (Utils.elmi flags filePath) WriteMode $ \handle ->
+        createDirectoryIfMissing True . dropFileName $ elmi
+        writeFile elmo (JS.generate canonicalModule)
+        withBinaryFile elmi WriteMode $ \handle ->
           L.hPut handle (Binary.encode (name, interfs))
 
-update :: String -> Module.Interface -> Bool -> Build ()
+update :: ModuleId -> Module.Interface -> Bool -> Build ()
 update name inter wasUpdated =
   do modify (Map.insert name (wasUpdated, inter))
      tell (Last . Just $ name)

--- a/compiler/Build/SrcFile.hs
+++ b/compiler/Build/SrcFile.hs
@@ -1,0 +1,61 @@
+{-# OPTIONS_GHC -Wall #-}
+module Build.SrcFile (SrcFile, UnresolvedSrcFile, ResolvedSrcFile, getDeps, header, load, moduleId, moduleName, modulePath, path, pkg, resolve, resolvedDeps)
+       where
+
+import Control.Arrow ((&&&))
+import Control.Monad.Error (ErrorT, throwError)
+import Control.Monad.Trans (liftIO)
+import System.FilePath ((</>))
+
+import AST.ProgramHeader (ProgramHeader(..), ModuleName, ModuleId)
+import qualified AST.ProgramHeader as ProgramHeader
+import qualified Elm.Internal.Name as Package
+import Parse.Helpers (iParse)
+import Parse.Parse (programHeader)
+
+-- | This module is intended to be imported qualified.
+
+type UnresolvedSrcFile = SrcFile ()
+type ResolvedSrcFile = SrcFile [ModuleId] -- ^ Includes resolved dependencies (package and module)
+
+data SrcFile meta = SrcFile
+    { _path     :: FilePath
+    , _pkg      :: Maybe Package.Name
+    , _header   :: ProgramHeader
+    , _metadata :: meta
+    } deriving (Show)
+
+pkg :: SrcFile a -> Maybe Package.Name
+pkg = _pkg
+
+header :: SrcFile a -> ProgramHeader
+header = _header
+
+moduleName :: SrcFile a -> ModuleName
+moduleName = ProgramHeader._names . header
+
+moduleId :: SrcFile a -> ModuleId
+moduleId = pkg &&& moduleName
+
+modulePath :: SrcFile a -> FilePath
+modulePath src = foldr1 (</>) (_names . header $ src)
+
+getDeps :: SrcFile a -> [ModuleName]
+getDeps = map fst . ProgramHeader._imports . header
+
+resolvedDeps :: ResolvedSrcFile -> [ModuleId]
+resolvedDeps = _metadata
+
+path :: SrcFile a -> FilePath
+path = _path
+
+resolve :: UnresolvedSrcFile -> [ModuleId] -> ResolvedSrcFile
+resolve (SrcFile pth pkg' headr _) ids = SrcFile pth pkg' headr ids
+
+load :: Maybe Package.Name -> FilePath -> ErrorT String IO UnresolvedSrcFile
+load name f = do
+  txt <- liftIO $ readFile f
+  case iParse programHeader txt of
+    Left err -> throwError ("Error parsing file " ++ f ++ show err)
+    Right hdr ->
+      return $ SrcFile f name hdr ()

--- a/compiler/Build/Utils.hs
+++ b/compiler/Build/Utils.hs
@@ -4,24 +4,34 @@ module Build.Utils where
 import Control.Monad.Error
 import System.Directory (doesFileExist)
 import System.Environment (getEnv)
-import System.FilePath ((</>), replaceExtension)
+import System.FilePath ((</>), (<.>))
+
 import qualified Build.Flags as Flag
 import qualified Build.Print as Print
+import Build.SrcFile (SrcFile)
+import qualified Build.SrcFile as SrcFile
+import qualified Elm.Internal.Name as Name
 import qualified Paths_Elm as This
 
-buildPath :: Flag.Flags -> FilePath -> String -> FilePath
-buildPath flags filePath ext =
-    Flag.build_dir flags </> replaceExtension filePath ext
+buildPath :: Flag.Flags -> SrcFile a -> String -> FilePath
+buildPath = flaggedPath Flag.build_dir
 
-cachePath :: Flag.Flags -> FilePath -> String -> FilePath
-cachePath flags filePath ext =
-    Flag.cache_dir flags </> replaceExtension filePath ext
+cachePath :: Flag.Flags -> SrcFile a -> String -> FilePath
+cachePath = flaggedPath Flag.cache_dir
 
-elmo :: Flag.Flags -> FilePath -> FilePath
+flaggedPath :: (Flag.Flags -> FilePath) -> Flag.Flags -> SrcFile a -> String -> FilePath
+flaggedPath acc flags srcFile ext =
+  acc flags </> pkgPath </> modul <.> ext
+  where pkgPath = case SrcFile.pkg srcFile of
+          Nothing -> ""
+          Just name -> Name.toFilePath name
+        modul = SrcFile.modulePath srcFile
+
+elmo :: Flag.Flags -> SrcFile a -> FilePath
 elmo flags filePath =
     cachePath flags filePath "elmo"
 
-elmi :: Flag.Flags -> FilePath -> FilePath
+elmi :: Flag.Flags -> SrcFile a -> FilePath
 elmi flags filePath =
     cachePath flags filePath "elmi"
 

--- a/compiler/Parse/Module.hs
+++ b/compiler/Parse/Module.hs
@@ -6,6 +6,7 @@ import Text.Parsec hiding (newline,spaces)
 
 import Parse.Helpers
 import AST.Module (ImportMethod(..))
+import AST.ProgramHeader (ModuleName)
 import AST.Variable (Listing(..), Value(..), openListing)
 
 getModuleName :: String -> Maybe String
@@ -30,15 +31,15 @@ moduleDef = do
   reserved "where"
   return (names, exports)
 
-imports :: IParser [(String, ImportMethod)]
+imports :: IParser [(ModuleName, ImportMethod)]
 imports = option [] ((:) <$> import' <*> many (try (freshLine >> import')))
 
-import' :: IParser (String, ImportMethod)
+import' :: IParser (ModuleName, ImportMethod)
 import' =
   do reserved "import"
      whitespace
-     name <- intercalate "." <$> dotSep1 capVar
-     (,) name <$> option (As name) method
+     names <- dotSep1 capVar
+     (,) names <$> option (As (intercalate "." names)) method
   where
     method :: IParser ImportMethod
     method = as' <|> importing'

--- a/tests/libraries/LibraryTest.hs
+++ b/tests/libraries/LibraryTest.hs
@@ -31,7 +31,7 @@ main = do
   -- run tests
   let files = [ "IO" </> "share" </> "prescript.js"
               , Elm.runtime
-              , "build" </> testFile <.> "js"
+              , "build" </> "Main" <.> "js"
               , "IO" </> "share" </> "handler.js"
               ]
       testRunner = "build" </> "TestRunner.js"


### PR DESCRIPTION
Files in --src-dirs are treated as if they were in the current
directory. Files in a package named "packageName" will have build files
put in cache/packageName/

Adds new representation of elm source file paths (SrcFile) that keeps
track of metadata concerning sources.

Reworking of https://github.com/elm-lang/Elm/pull/709. Fixes https://github.com/elm-lang/Elm/issues/618.
