### PR TITLE
End cabal hell

### DIFF
--- a/Elm.cabal
+++ b/Elm.cabal
@@ -99,29 +99,29 @@ Library
                        Build.Utils,
                        Paths_Elm
 
-  Build-depends:       aeson < 0.9,
-                       aeson-pretty < 0.8,
+  Build-depends:       aeson >= 0.7 && < 0.9,
+                       aeson-pretty >= 0.7 && < 0.8,
                        base >=4.2 && <5,
                        binary >= 0.7.0.0 && < 0.8,
                        blaze-html >= 0.5 && < 0.8,
-                       blaze-markup < 0.7,
-                       bytestring < 0.11,
-                       cheapskate < 0.2,
-                       cmdargs < 0.11,
+                       blaze-markup >= 0.5.1 && < 0.7,
+                       bytestring >= 0.9 && < 0.11,
+                       cheapskate >= 0.1 && < 0.2,
+                       cmdargs >= 0.7 && < 0.11,
                        containers >= 0.3 && < 0.6,
-                       directory < 2.0,
-                       filepath < 2.0,
-                       highlighting-kate < 0.6,
-                       indents < 0.4,
+                       directory >= 1.0 && < 2.0,
+                       filepath >= 1 && < 2.0,
+                       highlighting-kate >= 0.5 && < 0.6,
+                       indents >= 0.3 && < 0.4,
                        language-ecmascript >=0.15 && < 0.17,
                        language-glsl >= 0.0.2 && < 0.1,
                        mtl >= 2 && < 3,
                        parsec >= 3.1.1 && < 3.5,
-                       pretty < 2.0,
+                       pretty >= 1.0 && < 2.0,
                        text >= 1 && < 2,
                        transformers >= 0.2 && < 0.5,
-                       union-find < 0.3,
-                       unordered-containers < 0.3
+                       union-find >= 0.2 && < 0.3,
+                       unordered-containers >= 0.1 && < 0.3
 
 Executable elm
   Main-is:             Compiler.hs
@@ -189,29 +189,29 @@ Executable elm
                        Build.Utils,
                        Paths_Elm
 
-  Build-depends:       aeson < 0.9,
-                       aeson-pretty < 0.8,
+  Build-depends:       aeson >= 0.7 && < 0.9,
+                       aeson-pretty >= 0.7 && < 0.8,
                        base >=4.2 && <5,
                        binary >= 0.7.0.0 && < 0.8,
                        blaze-html >= 0.5 && < 0.8,
-                       blaze-markup < 0.7,
-                       bytestring < 0.11,
-                       cheapskate < 0.2,
-                       cmdargs < 0.11,
+                       blaze-markup >= 0.5.1 && < 0.7,
+                       bytestring >= 0.9 && < 0.11,
+                       cheapskate >= 0.1 && < 0.2,
+                       cmdargs >= 0.7 && < 0.11,
                        containers >= 0.3 && < 0.6,
-                       directory < 2.0,
-                       filepath < 2.0,
-                       highlighting-kate < 0.6,
-                       indents < 0.4,
+                       directory >= 1.0 && < 2.0,
+                       filepath >= 1 && < 2.0,
+                       highlighting-kate >= 0.5 && < 0.6,
+                       indents >= 0.3 && < 0.4,
                        language-ecmascript >=0.15 && < 0.17,
                        language-glsl >= 0.0.2 && < 0.1,
                        mtl >= 2 && < 3,
                        parsec >= 3.1.1 && < 3.5,
-                       pretty < 2.0,
+                       pretty >= 1.0 && < 2.0,
                        text >= 1 && < 2,
                        transformers >= 0.2 && < 0.5,
-                       union-find < 0.3,
-                       unordered-containers < 0.3
+                       union-find >= 0.2 && < 0.3,
+                       unordered-containers >= 0.1 && < 0.3
 
 Executable elm-doc
   Main-is:             Docs.hs
@@ -235,23 +235,23 @@ Executable elm-doc
                        Parse.Pattern,
                        Parse.Type
 
-  Build-depends:       aeson < 0.9,
-                       aeson-pretty < 0.8,
+  Build-depends:       aeson >= 0.7 && < 0.9,
+                       aeson-pretty >= 0.7 && < 0.8,
                        base >=4.2 && <5,
                        binary >= 0.7.0.0 && < 0.8,
-                       bytestring < 0.11,
-                       cmdargs < 0.11,
+                       bytestring >= 0.9 && < 0.11,
+                       cmdargs >= 0.7 && < 0.11,
                        containers >= 0.3 && < 0.6,
-                       directory < 2.0,
-                       filepath < 2.0,
-                       indents < 0.4,
+                       directory >= 1.0 && < 2.0,
+                       filepath >= 1 && < 2.0,
+                       indents >= 0.3 && < 0.4,
                        language-glsl >= 0.0.2 && < 0.1,
                        mtl >= 2 && < 3,
                        parsec >= 3.1.1 && < 3.5,
-                       pretty < 2.0,
+                       pretty >= 1.0 && < 2.0,
                        text >= 1 && < 2,
                        transformers >= 0.2 && < 0.5,
-                       union-find < 0.3
+                       union-find >= 0.2 && < 0.3
 
 Test-Suite compiler-tests
   Type:            exitcode-stdio-1.0
@@ -263,43 +263,43 @@ Test-Suite compiler-tests
                    AST.Helpers
                    AST.Literal
                    AST.PrettyPrint
-  build-depends:   test-framework < 0.9,
-                   test-framework-hunit < 0.4,
+  build-depends:   test-framework > 0.8 && < 0.9,
+                   test-framework-hunit >= 0.3 && < 0.4,
                    test-framework-quickcheck2 >= 0.3 && < 0.4,
-                   HUnit < 2,
+                   HUnit >= 1.1 && < 2,
                    QuickCheck >= 2 && < 3,
-                   aeson < 0.9,
-                   aeson-pretty < 0.8,
+                   aeson >= 0.7 && < 0.9,
+                   aeson-pretty >= 0.7 && < 0.8,
                    base >=4.2 && <5,
                    binary >= 0.7.0.0 && < 0.8,
                    blaze-html >= 0.5 && < 0.8,
-                   blaze-markup < 0.7,
-                   bytestring < 0.11,
-                   cheapskate < 0.2,
-                   cmdargs < 0.11,
+                   blaze-markup >= 0.5.1 && < 0.7,
+                   bytestring >= 0.9 && < 0.11,
+                   cheapskate >= 0.1 && < 0.2,
+                   cmdargs >= 0.7 && < 0.11,
                    containers >= 0.3 && < 0.6,
-                   directory < 2.0,
+                   directory >= 1.0 && < 2.0,
                    Elm,
-                   filemanip < 0.4,
-                   filepath < 2.0,
-                   highlighting-kate < 0.6,
-                   indents < 0.4,
+                   filemanip >= 0.3.5 && < 0.4,
+                   filepath >= 1 && < 2.0,
+                   highlighting-kate >= 0.5 && < 0.6,
+                   indents >= 0.3 && < 0.4,
                    language-ecmascript >=0.15 && < 0.17,
                    language-glsl >= 0.0.2 && < 0.1,
                    mtl >= 2 && < 3,
                    parsec >= 3.1.1 && < 3.5,
-                   pretty < 2.0,
+                   pretty >= 1.0 && < 2.0,
                    text >= 1 && < 2,
                    transformers >= 0.2 && < 0.5,
-                   union-find < 0.3,
-                   unordered-containers < 0.3
+                   union-find >= 0.2 && < 0.3,
+                   unordered-containers >= 0.1 && < 0.3
 
 Test-Suite library-tests
   Type:            exitcode-stdio-1.0
   Hs-Source-Dirs:  tests/libraries
   Main-is:         LibraryTest.hs
   build-depends:   base >= 4.2 && <5,
-                   directory < 2.0,
+                   directory >= 1.0 && < 2.0,
                    Elm,
-                   filepath < 2.0,
-                   process < 2.0
+                   filepath >= 1 && < 2.0,
+                   process >= 1 && < 2.0


### PR DESCRIPTION
I've added lower and upper bounds to every dependency. See the third commit message for more detail on lower bounds.

With upper bounds comes difficulty when new packages are updated. To make sure we move fast to fix this, we should subscribe to this rss feed: http://packdeps.haskellers.com/feed?needle=exact%3AElm and update minor version numbers to allow newer dependencies when we can
