### PR TITLE
Debugger

### DIFF
--- a/runtime/Debugger.js
+++ b/runtime/Debugger.js
@@ -181,8 +181,8 @@ function debugModule(module, runtime) {
     eventsUntilSnapshot = EVENTS_PER_SAVE - (position % EVENTS_PER_SAVE);
     snapshots = snapshots.slice(0, lastSnapshotPosition + 1);
 
-    if (position > 0) {
-      var lastEventTime = recordedEvents[position-1].timestep;
+    if (position < getRecordedEventsLength()) {
+      var lastEventTime = recordedEvents[position].timestep;
       var scrubTime = runtime.timer.now() - lastEventTime;
       runtime.timer.addDelay(scrubTime);
     }
@@ -251,10 +251,6 @@ function debuggerInit(debugModule, runtime, hotSwapState /* =undefined */) {
   function continueProgram() {
     if (debugModule.getPaused())
     {
-      if (currentEventIndex === 0) {
-        restartProgram();
-        return;
-      }
       var closestSnapshotIndex =
           Math.floor(currentEventIndex / EVENTS_PER_SAVE) * EVENTS_PER_SAVE;
       resetProgram(currentEventIndex);


### PR DESCRIPTION
There should still be a refactoring pass to change variable names and make the code clearer throughout `debugger.js`.

The `if` is still in there because when you `setContinue(<recordedEventsLength>)` there should be no extra delay added from your new continue position. The new position is normally in the past but when you `setContinue(<recordedEventsLength>)`, the continuing position is in the now for `elm`, so we shouldn't add a scrub-time delay.
