### PR TITLE
Changes representation of empty list in Collage

### DIFF
--- a/runtime/Render/Collage.js
+++ b/runtime/Render/Collage.js
@@ -21,7 +21,7 @@ function trace(ctx, path) {
 }
 
 function line(ctx,style,path) {
-    style.dashing.ctor === 'Nil' ? trace(ctx, path) : customLineHelp(ctx, style, path);
+    style.dashing.ctor === '[]' ? trace(ctx, path) : customLineHelp(ctx, style, path);
     ctx.scale(1,-1);
     ctx.stroke();
 }


### PR DESCRIPTION
Function `line` used `'Nil`' representation of empty list which cause execution of `customLineHelp` function instead of `trace`
