### PR TITLE
Fixed bug in parsing of Constraints

### DIFF
--- a/compiler/Elm/Internal/Constraint.hs
+++ b/compiler/Elm/Internal/Constraint.hs
@@ -58,7 +58,7 @@ parseLower str = case str of
 parseUpper :: String -> Maybe Endpoint
 parseUpper str = case str of
   '<' : '=' : rest -> Included <$> V.fromString rest
-  '<' : rest -> Included <$> V.fromString rest
+  '<' : rest -> Excluded <$> V.fromString rest
   _ -> Nothing
 
 fromString :: String -> Maybe Constraint


### PR DESCRIPTION
Nasty bug which parsed ">=1.0 &lt;1.1" to same constraint as "&gt;=1.0 <=1.1"
