### PR TITLE
Document Field.defaultStyle, id -> identity

### DIFF
--- a/libraries/Array.elm
+++ b/libraries/Array.elm
@@ -30,7 +30,7 @@ data Array a = Array
 {-| Initialize an array. `initialize n f` creates an array of length `n` with
 the element at index `i` initialized to the result of `(f i)`.
 
-      initialize 4 id          == fromList [0,1,2,3]
+      initialize 4 identity    == fromList [0,1,2,3]
       initialize 4 (\n -> n*n) == fromList [0,1,4,9]
       initialize 4 (always 0)  == fromList [0,0,0,0]
 -}

--- a/libraries/Graphics/Input.elm
+++ b/libraries/Graphics/Input.elm
@@ -104,7 +104,7 @@ customButton = Native.Graphics.Input.customButton
 
       boxes : Bool -> Element
       boxes checked =
-          let box = container 40 40 middle (checkbox check.handle id checked)
+          let box = container 40 40 middle (checkbox check.handle identity checked)
           in  flow right [ box, box, box ]
 
       main : Signal Element

--- a/libraries/Graphics/Input/Field.elm
+++ b/libraries/Graphics/Input/Field.elm
@@ -11,7 +11,7 @@ text fields programmatically.
 @docs Content, Selection, Direction, noContent
 
 # Field Style
-@docs Style, Outline, noOutline, Highlight, noHighlight, Dimensions, uniformly
+@docs defaultStyle, Style, Outline, noOutline, Highlight, noHighlight, Dimensions, uniformly
 -}
 
 import Color (Color)
@@ -140,7 +140,7 @@ to match what they have entered.
       name = input noContent
 
       nameField : Signal Element
-      nameField = field defaultStyle name.handle id "Name" <~ name.signal
+      nameField = field defaultStyle name.handle identity "Name" <~ name.signal
 
 When we use the `field` function, we first give it a visual style. This is
 the first argument so that it is easier to define your own custom field


### PR DESCRIPTION
Two docs fixes:
- `Graphics.Field.defaultStyle` was undocumented, but referred to in an example, so I assume this was an oversight.
- Chased down all uses of `id` and replaced them with `identity`. I haven't looked for other 0.13 changes. Long term I'd like to see all docs examples automatically extracted and tested (for compilation without error).
