### PR TITLE
Use default background color instead of transparent, fixes #797

### DIFF
--- a/runtime/Render/Element.js
+++ b/runtime/Render/Element.js
@@ -392,7 +392,7 @@ function updateProps(node, curr, next) {
 
     var nextColor = nextProps.color.ctor === 'Just'
         ? colorToCss(nextProps.color._0)
-        : 'transparent';
+        : '';
     if (node.style.backgroundColor !== nextColor) {
         node.style.backgroundColor = nextColor;
     }


### PR DESCRIPTION
This commmit is a fix for #797. It keeps using the default background of the node instead of changing it to 'transparent'.
