### PR TITLE
Implemented multi-file compiling as a library function

### DIFF
--- a/compiler/Elm/Internal/Utils.hs
+++ b/compiler/Elm/Internal/Utils.hs
@@ -1,6 +1,6 @@
 {- | This module exports functions for compiling Elm to JS.
 -}
-module Elm.Internal.Utils (compile, moduleName, nameAndImports) where
+module Elm.Internal.Utils (compile, compileInOrder, moduleName, nameAndImports) where
 
 import qualified Data.List as List
 import qualified Generate.JavaScript as JS
@@ -11,15 +11,48 @@ import Parse.Parse (dependencies)
 import qualified Text.PrettyPrint as P
 import qualified Metadata.Prelude as Prelude
 import System.IO.Unsafe
+import qualified AST.Module as Module
+import Data.Foldable (foldlM)
+import Data.Map (insert)
+
+-- |Helper function to check if a module compiled correctly, and either render it
+--  or generate an error message 
+canonicalToString :: Either [P.Doc] Module.CanonicalModule -> Either String String
+canonicalToString canon = case canon of
+      Left docs -> Left . unlines . List.intersperse "" $ map P.render docs
+      Right modul -> Right $ JS.generate modul
 
 -- |This function compiles Elm code to JavaScript. It will return either
 --  an error message or the compiled JS code.
 compile :: String -> Either String String
-compile source =
-    case Source.build False interfaces source of
-      Left docs -> Left . unlines . List.intersperse "" $ map P.render docs
-      Right modul -> Right $ JS.generate modul
+compile source = canonicalToString $ Source.build False interfaces source
 
+-- |Helper function for compileAll, used in a monadic foldL
+-- Takes the last module compiled, and uses it in the interface of the next one, with possibility of failure.       
+buildFun :: (String, Module.Interfaces, Module.CanonicalModule) -> (String, String) -> Either [P.Doc] (String, Module.Interfaces, Module.CanonicalModule)
+buildFun (interName, oldInters, canon) (name, source) = bundleResult `fmap` eitherCanon
+    where 
+        bundleResult c  = (name, newInters, c)
+        newInters = insert interName (Module.toInterface canon) oldInters 
+        eitherCanon = Source.build False newInters source
+
+-- |Helper function to get the module name of a source code string        
+getName source = case Parser.getModuleName source of
+                       Just n -> n
+                       Nothing -> "Main"         
+        
+-- |Compile several modules into one javascript output, in the order given.
+--  The last element of the list is assumed to be the main module
+--  All modules should occur after their dependencies in the list
+compileInOrder :: [String] -> Either String String
+compileInOrder [] = Right ""
+compileInOrder sources = canonicalToString $ do
+    let ((firstName, firstSource) : otherNameSources) = map (\s -> (getName s,s)) sources
+    firstCanonical <- Source.build False interfaces firstSource
+    let firstBundle = (getName firstSource, interfaces, firstCanonical )
+    (_, _, finalCanonical) <- foldlM buildFun firstBundle otherNameSources
+    return finalCanonical
+  
 {-# NOINLINE interfaces #-}
 interfaces :: M.Interfaces
 interfaces = unsafePerformIO $ Prelude.interfaces False


### PR DESCRIPTION
I've implemented a function that can compile multiple modules. It will make Elm much easier to use as a library, which will be ideal for using elm with web-frameworks. Also, if we every try to make a web IDE, something similar to FP-haskell centre, then this will be very useful.

I'm writing this with Haskelm in mind, but I can think of a lot of other uses for it.

I wasn't sure how to test it using the test-suite, but I've pasted output from a basic cabal-repl test below.

```
Prelude Elm.Internal.Dependencies> import Elm.Internal.Utils

Prelude Elm.Internal.Utils Elm.Internal.Dependencies> let s1 = "module Foo where
\nbar = 3"
Prelude Elm.Internal.Utils Elm.Internal.Dependencies> let s2 = "module Main wher
e\nimport Json\nimport Foo\nx = Json.fromString\n\ns = Foo.bar\nmain = asText 3"

Prelude Elm.Internal.Utils Elm.Internal.Dependencies> compileInOrder [s1, s2]
Right "Elm.Main = Elm.Main || {};\nElm.Main.make = function (_elm) {\n   \"use s
trict\";\n   _elm.Main = _elm.Main || {};\n   if (_elm.Main.values)\n   return _
elm.Main.values;\n   var _op = {},\n   _N = Elm.Native,\n   _U = _N.Utils.make(_
elm),\n   _L = _N.List.make(_elm),\n   _A = _N.Array.make(_elm),\n   _E = _N.Err
or.make(_elm),\n   $moduleName = \"Main\",\n   $Foo = Elm.Foo.make(_elm),\n   $J
son = Elm.Json.make(_elm),\n   $Text = Elm.Text.make(_elm);\n   var main = $Text
.asText(3);\n   var s = $Foo.bar;\n   var x = $Json.fromString;\n   _elm.Main.va
lues = {_op: _op\n                      ,x: x\n                      ,s: s\n
                  ,main: main};\n   return _elm.Main.values;\n};"
```
