### PR TITLE
Embedded runtime as string lits

### DIFF
--- a/elm-compiler.cabal
+++ b/elm-compiler.cabal
@@ -119,6 +119,7 @@ Library
         containers >= 0.3 && < 0.6,
         directory >= 1.0 && < 2.0,
         filepath >= 1 && < 2.0,
+        file-embed >= 0.0.5 && < 0.0.8,
         highlighting-kate >= 0.5 && < 0.6,
         indents >= 0.3 && < 0.4,
         language-ecmascript >=0.15 && < 0.17,

--- a/src/Elm/Compiler.hs
+++ b/src/Elm/Compiler.hs
@@ -1,15 +1,18 @@
 {-# OPTIONS_GHC -Wall #-}
-{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleContexts, TemplateHaskell #-}
 module Elm.Compiler
     ( version
     , parseDependencies, compile
     , runtimePath, runtimeDebugPath
+    , runtimeSource, runtimeDebugSource
     ) where
 
 import Control.Monad.Error (MonadError, throwError)
 import qualified Data.List as List
 import qualified Data.Map as Map
 import qualified Text.PrettyPrint as P
+import qualified Data.FileEmbed as Embed
+import qualified Data.ByteString.Char8 as Char8
 
 import qualified AST.Module as Module (HeaderAndImports(HeaderAndImports), toInterface)
 import qualified Compile
@@ -80,9 +83,18 @@ runtimePath :: IO FilePath
 runtimePath =
     Utils.getAsset "compiler" Paths.getDataFileName "runtime/core.js"
 
+{-| Javascript source for the runtime.
+-}
+runtimeSource :: String
+runtimeSource = Char8.unpack $(Embed.embedFile "runtime/core.js")
 
 {-| Path to the debugger runtime.
 -}
 runtimeDebugPath :: IO FilePath
 runtimeDebugPath =
     Utils.getAsset "compiler" Paths.getDataFileName "runtime/debug.js"
+  
+{-| Javascript source for the debugger runtime.
+-}  
+runtimeDebugSource :: String
+runtimeDebugSource = Char8.unpack $(Embed.embedFile "runtime/debug.js")


### PR DESCRIPTION
This allows elm-compiler to be used as a Haskell library, going from Elm source to JS code without ever going into IO.

It avoids trickiness of having  to have core.js and debug.js installed somewhere on the user's system.

It's not super high priority. I can work around it, but I'll basically just end up embedding the current versions of the files in my elm-build-lib library, and manually updating them with each release of Elm. So having this would be more convenient.

Cons: introduces dependency on file-embed and template Haskell. Possibly increases size of executable by including the values as strings.
