### PR TITLE
Fix corner style of boxes in reactor

### DIFF
--- a/ui/browser/assets/styles.css
+++ b/ui/browser/assets/styles.css
@@ -84,6 +84,7 @@ a:hover {
   padding: 7px 12px;
   background-color: #fafafa;
   text-align: center;
+  border-radius: 5px;
 }
 
 .box-item {


### PR DESCRIPTION
I believe this fixes a style in reactor like this.

Before:
![image](https://user-images.githubusercontent.com/2568148/41506270-963a9b14-7255-11e8-8ab8-91c6c416b1e4.png)

After:
![image](https://user-images.githubusercontent.com/2568148/41506243-2e5ac2c6-7255-11e8-9b4d-42b1d2c62368.png)

Another plan would be adding `overflow: hidden;` (or scroll, auto ...) to `.box`.

```css
.box {
    border: 1px solid #c7c7c7;
    border-radius: 5px;
    margin-bottom: 40px;
+    overflow: hidden;
}
```
