### PR TITLE
final working version of Elm npm installer

### DIFF
--- a/installers/npm/bin/elm
+++ b/installers/npm/bin/elm
@@ -15,34 +15,34 @@
 // then on, it will run as normal without re-downloading.
 
 var install = require("..").install;
-var spawn = require("child_process").spawn;
+var child_process = require("child_process");
 var path = require("path");
 var fs = require("fs");
 
 // Make sure we get the right path even if we're executing from the symlinked
 // node_modules/.bin/ executable
+var interpreter = fs.realpathSync(process.argv[0]);
 var targetPath = fs.realpathSync(process.argv[1]);
+
+// Figure out the binary name as we'll eventually want to execute
+// this. Re-executing this script doesn't always work because of varying
+// permissions and modes of operation across platforms (for example, Windows has
+// some interesting edge cases here.)
+var binaryName = path.join(
+  __dirname,
+  "..",
+  "unpacked_bin",
+  path.basename(targetPath)
+);
+if (process.platform === "win") {
+  binaryName += ".exe";
+}
 
 // cd into the directory above bin/ so install() puts bin/ in the right place.
 process.chdir(path.join(path.dirname(targetPath), ".."));
 
 install(process.platform, process.arch).then(function() {
-  // we have to do this because the Elm binaries end in `.exe` on
-  // Windows. Really, we should fix this upstream (in binwrap), but in the
-  // interests of getting the installers out we're going to do this temporarily
-  // and ship a fix upstream later.
-  var replacement = process.argv.slice(2);
-  if (process.platform === "win32") {
-    replacement += ".exe";
-
-    if (fs.existsSync(replacement)) {
-      // if we replaced the bootstrap script, we should remove it. Otherwise we'd
-      // have two of them laying around on Windows (elm and elm.exe)
-      fs.unlinkSync(process.argv.slice(2));
-    }
-  }
-
-  spawn(targetPath, replacement, {
-    stdio: "inherit"
-  }).on("exit", process.exit);
+  child_process
+    .spawn(binaryName, process.argv.slice(2), { stdio: "inherit" })
+    .on("exit", process.exit);
 });

--- a/installers/npm/bin/elm
+++ b/installers/npm/bin/elm
@@ -27,7 +27,22 @@ var targetPath = fs.realpathSync(process.argv[1]);
 process.chdir(path.join(path.dirname(targetPath), ".."));
 
 install(process.platform, process.arch).then(function() {
-  spawn(targetPath, process.argv.slice(2), {
+  // we have to do this because the Elm binaries end in `.exe` on
+  // Windows. Really, we should fix this upstream (in binwrap), but in the
+  // interests of getting the installers out we're going to do this temporarily
+  // and ship a fix upstream later.
+  var replacement = process.argv.slice(2);
+  if (process.platform === "win32") {
+    replacement += ".exe";
+
+    if (fs.existsSync(replacement)) {
+      // if we replaced the bootstrap script, we should remove it. Otherwise we'd
+      // have two of them laying around on Windows (elm and elm.exe)
+      fs.unlinkSync(process.argv.slice(2));
+    }
+  }
+
+  spawn(targetPath, replacement, {
     stdio: "inherit"
   }).on("exit", process.exit);
 });

--- a/installers/npm/package.json
+++ b/installers/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "elm",
-  "version": "0.19.0",
+  "version": "0.19.0-bugfix1",
   "description": "The Elm Platform: Binaries for the Elm programming language.",
   "main": "index.js",
   "preferGlobal": true,

--- a/installers/npm/package.json
+++ b/installers/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "elm",
-  "version": "0.19.0-bugfix1",
+  "version": "0.19.0-bugfix2",
   "description": "The Elm Platform: Binaries for the Elm programming language.",
   "main": "index.js",
   "preferGlobal": true,


### PR DESCRIPTION
currently published as `elm@rc3` if you'd like to try it.