### PR TITLE
Set TERMINFO_DIRS environment variable when unset

### DIFF
--- a/ui/terminal/src/Main.hs
+++ b/ui/terminal/src/Main.hs
@@ -18,6 +18,7 @@ import qualified Elm.Package as Pkg
 import qualified Generate.Output as Output
 import Terminal.Args
 import Terminal.Args.Helpers
+import Terminal.Env
 
 import qualified Bump
 import qualified Develop
@@ -36,6 +37,7 @@ import qualified Repl
 main :: IO ()
 main =
   do  setLocaleEncoding utf8
+      Terminal.Env.configure
       complex intro outro
         [ repl
         , init

--- a/ui/terminal/src/Terminal/Env.hs
+++ b/ui/terminal/src/Terminal/Env.hs
@@ -1,0 +1,43 @@
+module Terminal.Env (configure) where
+
+
+import Control.Monad (when)
+
+import qualified Data.Maybe as Maybe
+import qualified Data.List as List
+import qualified System.Environment as Env
+
+
+
+-- CONFIGURE
+
+
+configure :: IO ()
+configure =
+  do configureTerminfo
+
+
+
+-- TERMINFO
+
+
+configureTerminfo :: IO ()
+configureTerminfo =
+  let
+    variable = "TERMINFO_DIRS"
+  in
+  do terminfoDirs <- Env.lookupEnv variable
+     when (Maybe.isNothing terminfoDirs) $
+       Env.setEnv variable terminfoSearchPath
+
+
+terminfoSearchPath :: String
+terminfoSearchPath =
+  List.intercalate ":"
+    [ "/etc/terminfo"
+    , "/lib/terminfo"
+    , "/usr/share/terminfo"
+    , "/usr/lib/terminfo"
+    , "/usr/local/share/terminfo"
+    , "/usr/local/lib/terminfo"
+    ]


### PR DESCRIPTION
This fixes https://github.com/elm/compiler/issues/1768.

## Details

Considering that we don't control the `ncurses` library package, I think it is faster and safer to fix it in `elm` itself (see [here for details](https://github.com/elm/compiler/issues/1768#issuecomment-417286834))

Here is how the terminal description files are searched (`man 5 TERMINFO`):
```
The  ncurses library searches for terminal descriptions in several places.  It uses only the first description
found.  The library has a compiled-in list of places to search which can be overridden  by  environment  vari‐
ables.  Before starting to search, ncurses eliminates duplicates in its search list.

·   If  the  environment variable TERMINFO is set, it is interpreted as the pathname of a directory containing
    the compiled description you are working on.  Only that directory is searched.

·   If TERMINFO is not set, ncurses will instead look in the directory $HOME/.terminfo for a compiled descrip‐
    tion.

·   Next,  if the environment variable TERMINFO_DIRS is set, ncurses will interpret the contents of that vari‐
    able as a list of colon-separated directories (or database files) to be searched.

    An empty directory name (i.e., if the variable begins or ends with a colon, or contains  adjacent  colons)
    is interpreted as the system location /etc/terminfo.

·   Finally, ncurses searches these compiled-in locations:

    ·   a list of directories (no default value), and 

    ·   the system terminfo directory, /etc/terminfo (the compiled-in default).
```

This patch use the `TERMINFO_DIRS` environment variable (before `haskeline` uses it) because:
* it allows to set several directories to search
* it is used just before the `ncurses` compiled-in directories, so the behavior is similar
* it is not intrusive, as we set it only if it was unset, so this does not prevent the user to set it. Also this does not prevent the user to use `~/.terminfo` or the `TERMINFO` environment variable, and compiled-in directories are still searched.

## Tests

Here is how I have tested the patch:
```
$ strace ./elm repl 2>&1 | grep terminfo 
stat("/home/dmy/.terminfo", 0x37457a0)  = -1 ENOENT (No such file or directory)
stat("/etc/terminfo", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
stat("/lib/terminfo", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
stat("/usr/share/terminfo", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
stat("/usr/lib/terminfo", 0x3745950)    = -1 ENOENT (No such file or directory)
stat("/usr/local/share/terminfo", 0x3745950) = -1 ENOENT (No such file or directory)
stat("/usr/local/lib/terminfo", 0x3745950) = -1 ENOENT (No such file or directory)
```
Good, all the directories are searched.
```
$ TERMINFO_DIRS="/foo/terminfo:/bar/terminfo" strace ./elm repl 2>&1 | grep terminfo 
stat("/home/dmy/.terminfo", 0x25b7380)  = -1 ENOENT (No such file or directory)
stat("/foo/terminfo", 0x25b7380)        = -1 ENOENT (No such file or directory)
stat("/bar/terminfo", 0x25b7380)        = -1 ENOENT (No such file or directory)
stat("/etc/terminfo", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
stat("/usr/share/terminfo", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
```
also `TERMINFO_DIRS` can still be correctly overriden, and compiled-in directories are still used.

## Notes
* I made a `Terminal.Env` module in case we want to configure other environment variables (similar to `Terminal.Args`), but it may be more explicit to have a `Terminal.Terminfo` module and call `Terminal.Terminfo.configure` or something. Tell me if some modifications are wanted.
* The `SearchPath` term used in the patch comes [from unix](https://www.decf.berkeley.edu/help/unix/searchpath.html) and [System.FilePath.splitSearchPath](http://hackage.haskell.org/package/filepath-1.4.2.1/docs/System-FilePath-Posix.html#splitSearchPath)
* This pull request is merely to illustrate a solution. It is most likely not written as wanted, so feel free to close it and replace it by some other code similar in the intention.

Regards