### PR TITLE
Relax maximum language-glsl version to fix build with ghc-8.4

### DIFF
--- a/elm.cabal
+++ b/elm.cabal
@@ -246,7 +246,7 @@ Executable elm
         http-client >= 0.5 && < 0.6,
         http-client-tls >= 0.3 && < 0.4,
         http-types >= 0.9 && < 1.0,
-        language-glsl >= 0.0.2 && < 0.3,
+        language-glsl >= 0.0.2 && < 0.4,
         logict,
         mtl >= 2.2.1 && < 3,
         network >= 2.4 && < 2.7,


### PR DESCRIPTION
This is needed to be able to build `elm` with `ghc-8.4/base-11.4` (tested with `ghc-8.4.3`):

See https://github.com/noteed/language-glsl/pull/17#issuecomment-417923838 (version 0.3.0 released yesterday with the fix)

Maybe some tests should be performed to be sure that `elm-explorations/webgl` still work as expected though.