### PR TITLE
Add removal of bang operator (!) to upgrade doc

### DIFF
--- a/upgrade-docs/0.19.md
+++ b/upgrade-docs/0.19.md
@@ -91,6 +91,7 @@ Both are quite similar to the `elm-package.json` format, and `elm-upgrade` can h
 - `uncurry`
 - `curry`
 - `flip`
+- `(!)`
 
 Prefer named helper functions in these cases.
 


### PR DESCRIPTION
`(!) : model -> List (Cmd msg) -> ( model, Cmd msg )` was removed from core. This change mentions the removal in the upgrade document for 0.19.

https://package.elm-lang.org/packages/elm-lang/core/latest/Platform-Cmd#(!)