### PR TITLE
loosen dependency range for language-glsl

### DIFF
--- a/elm.cabal
+++ b/elm.cabal
@@ -246,7 +246,7 @@ Executable elm
         http-client >= 0.5 && < 0.6,
         http-client-tls >= 0.3 && < 0.4,
         http-types >= 0.9 && < 1.0,
-        language-glsl >= 0.0.2 && < 0.3,
+        language-glsl >= 0.0.2 && < 0.4,
         logict,
         mtl >= 2.2.1 && < 3,
         network >= 2.4 && < 2.7,


### PR DESCRIPTION
0.3.0 was recently released, and appears to work fine.  eases
packaging process for source-based distros.