### PR TITLE
Fix Map.!: given key is not an element in the map

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,10 @@
 elm-stuff
 dist
+dist-newstyle
 cabal-dev
 .cabal-sandbox/
 cabal.sandbox.config
 .DS_Store
 *~
+.ghc*
+cabal.project.local


### PR DESCRIPTION
I have an application using the package [mdgriffith/elm-ui](https://package.elm-lang.org/packages/mdgriffith/elm-ui/latest/).
One of the application `Msg`data constructors contains value of type `Element msg` from the elm-ui library.
Declaration of this type is:
```elm
type alias Element msg =
   Internal.Element msg
```
Neither the `Internal.Element msg` union type nor the `Internal` module is exposed from the library.
This pull request fixes function `extractUnion`, which couldn't find such module and type.

I'm not sure this is the right way how to solve this issue.
