### PR TITLE
Fix help example for elm diff in application

### DIFF
--- a/builder/src/Reporting/Exit/Diff.hs
+++ b/builder/src/Reporting/Exit/Diff.hs
@@ -35,7 +35,7 @@ toReport exit =
       Help.report "CANNOT DIFF APPLICATIONS" Nothing
         "I cannot perform diffs on applications, only packages! If you are\
         \ just curious to see a diff, try running this command:"
-        [ D.indent 4 $ D.green $ "elm diff elm/html 5.1.1 6.0.0"
+        [ D.indent 4 $ D.green $ "elm diff elm/json 1.0.0 1.1.2"
         ]
 
     Unpublished ->


### PR DESCRIPTION
The package (`elm/html`) was updated in a44fcf164e1858d812d91fd9323ce5a6df1f2947, but no such versions (5.1.1 nor 6.0.0) exist for it:

```
$ elm diff elm/html 5.1.1 6.0.0
-- UNKNOWN VERSION -------------------------------------------------------------

Version 5.1.1 has never been published, so I cannot diff against it.

Here are all the versions that HAVE been published:

    1.0.0

Want one of those instead?
```

Switched to `elm/json` because it has a minor version available:

```
$ elm diff elm/json 1.0.0 1.1.2
This is a MINOR change.

---- Json.Decode - MINOR ----

    Added:
        oneOrMore : (a -> List a -> value) -> Decoder a -> Decoder value
```