### PR TITLE
Fix contributor agreement link

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -6,7 +6,7 @@ possible.
 
 ## Licensing
 
-You need to sign the [contributor agreement](ContributorAgreement.pdf)
+You need to sign the [contributor agreement](https://github.com/elm/compiler/blob/master/ContributorAgreement.pdf)
 and send it to <info@elm-lang.org> before opening your pull request.
 
 ## Style Guide


### PR DESCRIPTION
GitHub is expanding the file name to `https://github.com/elm/compiler/blob/master/.github/ContributorAgreement.pdf`, which is a 404, so use the full URL instead.