### PR TITLE
Update GitHub issue template links

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,11 +1,11 @@
 BEFORE DELETING THIS:
 
-- Runtime error? https://github.com/elm-lang/elm-compiler/issues/1591
-- Type annotations? https://github.com/elm-lang/elm-compiler/issues/1214
-- Core libraries? https://github.com/elm-lang/core/issues
-- Bad error message? https://github.com/elm-lang/error-message-catalog/issues
-- Compiler hangs? https://github.com/elm-lang/elm-compiler/issues/1240
-- Parser / code gen problem? https://github.com/elm-lang/elm-compiler/labels/meta
+- Runtime error? https://github.com/elm/compiler/issues/1591
+- Type annotations? https://github.com/elm/compiler/issues/1214
+- Core libraries? https://github.com/elm/core/issues
+- Bad error message? https://github.com/elm/error-message-catalog/issues
+- Compiler hangs? https://github.com/elm/compiler/issues/1240
+- Parser / code gen problem? https://github.com/elm/compiler/labels/meta
 
 
 If none of that applies, write up a report that satisfies this checklist:


### PR DESCRIPTION
Hello!

This PR updates the links from the apparently old `elm-lang` organization to `elm`.

This is mostly superficial except for one link:

> Core libraries? https://github.com/elm-lang/core/issues

That page doesn't exist so you get redirected to the "pull requests" page of that repo. You have to go back to the root, go to the updated repo name and then go to issues. It's a bit confusing if you want to report an issue in the core library (which I wanted to do).

(Side note: I also found some other dead links in other `.md` files, for example the "stable" branch doesn't exist anymore... but I wanted to keep this PR focused)