### PR TITLE
Fix `==` operator parsing in REPL

### DIFF
--- a/compiler/src/Parse/Primitives/Variable.hs
+++ b/compiler/src/Parse/Primitives/Variable.hs
@@ -133,14 +133,14 @@ foreignUpper =
       let
         !newState = State fp end terminal indent row newCol ctx
         !name = N.fromForeignPtr fp start (end - start)
-        !foreign =
+        !foreign_ =
           if start == offset then
             Unqualified name
           else
             let !home = N.fromForeignPtr fp offset ((start - 1) - offset) in
             Qualified home name
       in
-      cok foreign newState noError
+      cok foreign_ newState noError
 
 
 foreignUpperHelp :: ForeignPtr Word8 -> Int -> Int -> Int -> (# Int, Int, Int #)


### PR DESCRIPTION
fixes: #1736 

Hi, I have reviewed mentioned issue which was just a simple parsing error caused by the fact that after parsing a symbol the parser didn't check whether the operator continues or not, which was leading to mistaking `=` with `==`. To solve the problem I check whether next character (if present) in the input right after the symbol belongs to the `binopCharSet`. If it is there - parsing fails like if we met non-matching char.

In my fix I have separated "operator" symbols from "section mark" symbols to allow use of `(+)` functions. It was necessary, because without this feature the "leftParen" would be rejected due to "binopChar" presence right after it.

As a side effect, I was forced to rename one local variable in `Parse/Primitives/Variable.hs` in order to compile, because it turned to be restricted id by GHC (https://wiki.haskell.org/Keywords#foreign). This identifier does not leak to the toplevel scope, so I hope it won't be a problem.

I was working on tag `0.19.0` as advised in the issue #1899 . I see there are some conflicts with the master – after the review I can resolve them and prepare to merge.

---------------

It is my first contribution to open source, I would be glad for any feedback and advises.