### PR TITLE
Reactor viewport initial scale

### DIFF
--- a/compiler/src/Generate/Html.hs
+++ b/compiler/src/Generate/Html.hs
@@ -23,6 +23,7 @@ sandwich moduleName javascript =
 <html>
 <head>
   <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>|] <> name <> [r|</title>
 </head>
 


### PR DESCRIPTION
I ran into the issues then I was developing mobile optimized pages, since the viewport meta attribute was not set for elm reactor generated page. I think this change is not yet complete, b/c we either need to mobile optimize all the reactor generated pages, or set this attribute in the pages that have compiled Elm code. 

Let me know if this change makes sense, and do we need to mobile optimize all pages. I didn't want to fully implement this feature, without consulting it before.
