### PR TITLE
upgrade binwrap to drop deprecated natives dependency

### DIFF
--- a/installers/npm/package.json
+++ b/installers/npm/package.json
@@ -39,6 +39,6 @@
     "elm": "bin/elm"
   },
   "dependencies": {
-    "binwrap": "0.1.4"
+    "binwrap": "0.2.0"
   }
 }


### PR DESCRIPTION
binwrap 0.2.0 doesn't have a transitive dependency on natives, which is a dicey package (See this note: https://github.com/addaleax/natives#caveat)

Specifically opening this PR because of test failures here https://github.com/NoRedInk/elm-css-files/pull/1