### PR TITLE
Typo in Exit.hs

### DIFF
--- a/builder/src/Reporting/Exit.hs
+++ b/builder/src/Reporting/Exit.hs
@@ -1971,7 +1971,7 @@ toGenerateReport problem =
             "The issue is that --optimize strips out info needed by `Debug` functions.\
             \ Here are two examples:"
         , D.indent 4 $ D.reflow $
-            "(1) It shortens record field names. This makes the generated JavaScript is\
+            "(1) It shortens record field names. This makes the generated JavaScript\
             \ smaller, but `Debug.toString` cannot know the real field names anymore."
         , D.indent 4 $ D.reflow $
             "(2) Values like `type Height = Height Float` are unboxed. This reduces\


### PR DESCRIPTION
Fixed a typo.

P.S. The contributor agreement link at [CONTRIBUTING.md](https://github.com/elm/compiler/blob/master/.github/CONTRIBUTING.md) is broken.