### PR TITLE
Typo fixing in the hint documents

### DIFF
--- a/hints/bad-recursion.md
+++ b/hints/bad-recursion.md
@@ -10,7 +10,7 @@ There are two problems that will lead you here, both of them pretty tricky:
 
 ## No Mutation
 
-Languages like JavaScript let you “reassign” variables. When you say `x = x + 1` it means: whatever `x` was pointing to, have it point to `x + 1` instead. This called *mutating* a variable. All values are immutable in Elm, so reassigning variables does not make any sense! Okay, so what *should* `x = x + 1` mean in Elm?
+Languages like JavaScript let you “reassign” variables. When you say `x = x + 1` it means: whatever `x` was pointing to, have it point to `x + 1` instead. This is called *mutating* a variable. All values are immutable in Elm, so reassigning variables does not make any sense! Okay, so what *should* `x = x + 1` mean in Elm?
 
 Well, what does it mean with functions? In Elm, we write recursive functions like this:
 

--- a/hints/comparing-custom-types.md
+++ b/hints/comparing-custom-types.md
@@ -54,7 +54,7 @@ add info (Table nextId dict) =
   )
 ```
 
-There are a couple nice thing about this approach:
+There are a couple nice things about this approach:
 
 1. The only way to get a new `User.Id` is to `add` information to a `User.Table`.
 2. All the operations on a `User.Table` are explicit. Does it make sense to remove users? To merge two tables together? Are there any special details to consider in those cases? This will always be captured explicitly in the interface of the `User` module.

--- a/hints/comparing-records.md
+++ b/hints/comparing-records.md
@@ -7,7 +7,7 @@ This page aims to catalog these scenarios and offer alternative paths that can g
 
 ## Sorting Records
 
-Say we want a `view` function that can show a list of students sorted by different characterists.
+Say we want a `view` function that can show a list of students sorted by different characteristics.
 
 We could create something like this:
 
@@ -23,7 +23,7 @@ type alias Student =
 type Order = Name | Age | GPA
 
 viewStudents : Order -> List Student -> Html msg
-viewStudents order studentns =
+viewStudents order students =
   let
     orderlyStudents =
       case order of
@@ -54,7 +54,7 @@ type alias Student =
   }
 
 viewStudents : Order -> List Student -> Html msg
-viewStudents order studentns =
+viewStudents order students =
   let
     orderlyStudents =
       case order of

--- a/hints/implicit-casts.md
+++ b/hints/implicit-casts.md
@@ -41,7 +41,7 @@ So for any ML-family language designed before Scala, it is safe to assume that i
 
   2. Based on experience reports from Scala users, it seemed like the convenience was not worth the hidden cost. Yes, you can convert `n` in `(n + 1.5)` and everything is nice, but when you are in larger programs that are sparsely annotated, it can be quite difficult to figure out what is going on.
 
-This user data may be confounded by the fact that Scala allows quite extensive conversions, not just from `Int` to `Float`, but I think it is worth taking seriously nonetheless. So it is _possible_, but it is has tradeoffs.
+This user data may be confounded by the fact that Scala allows quite extensive conversions, not just from `Int` to `Float`, but I think it is worth taking seriously nonetheless. So it is _possible_, but it has tradeoffs.
 
 
 ## Conclusion

--- a/hints/import-cycles.md
+++ b/hints/import-cycles.md
@@ -55,7 +55,7 @@ type alias User =
   }
 ```
 
-Notice that the `Comment` type alias is defined in terms of the `User` type alias and vice versa. Having recursive type aliases like this does not work! That problem is described in depth [here](recursive-alias), but the quick takeaway is that one `type alias` needs to become a `type` to break the recursion. So let’s try again:
+Notice that the `Comment` type alias is defined in terms of the `User` type alias and vice versa. Having recursive type aliases like this does not work! That problem is described in depth [here](recursive-alias.md), but the quick takeaway is that one `type alias` needs to become a `type` to break the recursion. So let’s try again:
 
 ```elm
 module BadCombination2 exposing (..)

--- a/hints/recursive-alias.md
+++ b/hints/recursive-alias.md
@@ -39,7 +39,7 @@ It is much easier to write down `Person` in a type, and then it will just expand
 
 ## Recursive type aliases?
 
-Okay, so lets say you have some type that may contain itself. In Elm, a common example of this is a comment that might have subcomments:
+Okay, so let's say you have some type that may contain itself. In Elm, a common example of this is a comment that might have subcomments:
 
 ```elm
 type alias Comment =
@@ -102,7 +102,7 @@ type Comment =
       }
 ```
 
-Now lets say you want to register an upvote on a comment:
+Now let's say you want to register an upvote on a comment:
 
 ```elm
 upvote : Comment -> Comment

--- a/hints/type-annotations.md
+++ b/hints/type-annotations.md
@@ -8,7 +8,7 @@ This document is going to outline the various things that can go wrong and show 
 
 ## Annotation vs. Definition
 
-The most common issue is with user-defined type variables that are too general. So lets say you have defined a function like this:
+The most common issue is with user-defined type variables that are too general. So let's say you have defined a function like this:
 
 ```elm
 addPair : (a, a) -> a
@@ -58,5 +58,3 @@ filter isOkay list =
 This case is very unfortunate because all the type annotations are correct, but there is a detail of how type inference works right now that **user-defined type variables are not shared between annotations**. This can lead to probably the worst type error messages we have because the problem here is that `a` in the outer annotation does not equal `a` in the inner annotation.
 
 For now the best route is to leave off the inner annotation. It is unfortunate, and hopefully we will be able to do a nicer thing in future releases.
-
-"""


### PR DESCRIPTION
I have been through the documents in the `hints/` folder, and I found a few typos/errors and one broken link.

## SSCCE

NA

## Additional Details

I noticed a missing word in the [bad-recursion](https://github.com/elm/compiler/blob/master/hints/bad-recursion.md) but I wasn't sure how to fix, and therefore refrained to do so in the PR. In the following sentence, I think that there is a missing word where I added *FOR*

> A common case is a JSON decoder *FOR* a discussion forums where a comment may have replies, which may have replies, which may have replies, etc.

Let me know if you wish for me to change anything or to take a look at something else.
