### PR TITLE
NPM readme fixes

### DIFF
--- a/installers/npm/README.md
+++ b/installers/npm/README.md
@@ -4,7 +4,7 @@
 
 There are installers for Mac and Windows available [here](https://github.com/elm/compiler/releases/tag/0.19.1). There are also binaries for direct download. These are the most reliable ways to install Elm.
 
-This package tries to download those binaries with `npm`. It is sometimes used by people intergating Elm into existing projects or workflows.
+This package tries to download those binaries with `npm`. It is sometimes used by people integrating Elm into existing projects or workflows.
 
 <br/>
 

--- a/installers/npm/README.md
+++ b/installers/npm/README.md
@@ -24,7 +24,7 @@ If this runs successfully, the `elm` binary should be available at:
 
 It should be possible to run `elm` from your terminal after this.
 
-If you run into trouble, check out [troubleshooting.md](troubleshooting.md).
+If you run into trouble, check out [troubleshooting.md](https://github.com/elm/compiler/blob/0.19.1/installers/npm/troubleshooting.md).
 
 <br/>
 


### PR DESCRIPTION
**Quick Summary:**

- Typo in the npm README
- Link to troubleshooting leads nowhere when accessed from https://www.npmjs.com/package/elm


## SSCCE

NA

## Additional Details

None
