### PR TITLE
Fix markdown links in installation instructions.

### DIFF
--- a/installers/README.md
+++ b/installers/README.md
@@ -11,6 +11,8 @@ The secret is that Elm is just a single executable file. If you are developing a
 
 The instructions for [Mac][mac] and [Linux][lin] explain how to do this in more detail. You can follow the same steps on Windows, but you need to do each step by hand. (E.g. download the file through your browser rather than with a terminal command.)
 
+[mac]: https://github.com/elm/compiler/blob/master/installers/mac/README.md
+[lin]: https://github.com/elm/compiler/blob/master/installers/linux/README.md
 
 <br/>
 


### PR DESCRIPTION
I was passing through and noticed some incomplete markdown links. I assumed that they were still intended to be links and added back the references from a previous commit.

Thanks!
