### PR TITLE
add Travis CI Linux x86_64 build and tags releases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ cabal-dev
 cabal.sandbox.config
 .DS_Store
 *~
+travis.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,28 @@
+language: minimal
+services: docker
+
+env:
+  global:
+    - LINUX_ARCHIVE=binary-for-linux-64-bit.gz
+
+before_install:
+  - docker build -t elm -f installers/linux/Dockerfile .
+  - docker cp $(docker create elm):/usr/local/bin/elm .
+  - gzip -9 -c elm > $LINUX_ARCHIVE
+
+deploy:
+  provider: releases
+  api_key:
+    secure: Yz2Lo4u9rZQ7Ee7ohAsrZpkqsYDUerCSMdSQIH8ryrf7phHhiloPEkTKsM+NupHqU/LEAVsunxbau4QrCEjA2vPavAPVk8cKomRUWK/YjbXHKa24hPkal2c+A2bnMQ6w3qYk/PjL9rW+Goq++/SNLcYZwHBV0Chl2blivMwWCSA=
+  file: $LINUX_ARCHIVE
+  skip_cleanup: true
+  on:
+    branch: master
+    tags: true
+
+notifications:
+  email:
+    recipients:
+      - rlefevre@dmy.fr
+    on_success: change
+    on_failure: change

--- a/installers/linux/Dockerfile
+++ b/installers/linux/Dockerfile
@@ -1,25 +1,39 @@
-# Create: https://gist.github.com/rlefevre/1523f47e75310e28eee243c9c5651ac9
-# Delete: docker system prune -a ; docker images -a
+# Based initially on https://gist.github.com/rlefevre/1523f47e75310e28eee243c9c5651ac9
+#
+# Build Linux x64 binary from elm compiler top-level directory:
+# $ docker build -t elm -f installers/linux/Dockerfile .
+#
+# Retrieve elm Linux binary:
+# $ docker cp $(docker create elm):/usr/local/bin/elm DESTINATION_DIRECTORY
+#
+# Delete docker elm image:
+# $ docker rmi elm
+#
+# Display all images:
+# $ docker images -a
+#
+# Delete all unused docker images:
+# $ docker system prune -a
 
-FROM alpine:3.10
+# Use Alpine 3.11 with GHC 8.6.5
+FROM alpine:3.11
 
-# branch
-ARG branch=master
-# commit or tag
-ARG commit=HEAD
+# Install packages required to build elm
+RUN apk add --no-cache ghc cabal wget musl-dev zlib-dev zlib-static ncurses-dev ncurses-static
 
-# Install required packages
-RUN apk add --update ghc cabal git musl-dev zlib-dev ncurses-dev ncurses-static wget
+WORKDIR /elm
 
-# Checkout elm compiler
-WORKDIR /tmp
-RUN git clone -b $branch https://github.com/elm/compiler.git
+# Import source code
+COPY builder builder/
+COPY compiler compiler
+COPY reactor reactor/
+COPY terminal terminal/
+COPY cabal.config elm.cabal LICENSE ./
 
-# Build a statically linked elm binary
-WORKDIR /tmp/compiler
-RUN git checkout $commit
-RUN rm worker/elm.cabal
+# Build statically linked elm binary
 RUN cabal new-update
-RUN cabal new-configure --disable-executable-dynamic --ghc-option=-optl=-static --ghc-option=-optl=-pthread
-RUN cabal new-build
-RUN strip -s ./dist-newstyle/build/x86_64-linux/ghc-8.4.3/elm-0.19.1/x/elm/build/elm/elm
+RUN cabal new-build --ghc-option=-optl=-static --ghc-option=-split-sections
+RUN cp ./dist-newstyle/build/x86_64-linux/ghc-*/elm-*/x/elm/build/elm/elm /usr/local/bin/elm
+
+# Remove debug symbols to optimize the binary size
+RUN strip -s /usr/local/bin/elm


### PR DESCRIPTION
* Linux binary released only on master tags
* emails sent only on status change (and only to myself for now)
* split-sections added to GHC options
* updated to Alpine 3.11 with ghc 8.6.5