### PR TITLE
fix: typo to link to contributor agreement

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -6,7 +6,7 @@ possible.
 
 ## Licensing
 
-You need to sign the [contributor agreement](ContributorAgreement.pdf)
+You need to sign the [contributor agreement](../ContributorAgreement.pdf)
 and send it to <info@elm-lang.org> before opening your pull request.
 
 ## Style Guide


### PR DESCRIPTION
**Quick Summary:** 

The link to contributor aggreement was broken since the file was moved to a subfolder

