### PR TITLE
remove unneeded slash characters from Dockerfile

### DIFF
--- a/installers/linux/Dockerfile
+++ b/installers/linux/Dockerfile
@@ -24,10 +24,10 @@ RUN apk add --no-cache ghc cabal wget musl-dev zlib-dev zlib-static ncurses-dev 
 WORKDIR /elm
 
 # Import source code
-COPY builder builder/
+COPY builder builder
 COPY compiler compiler
-COPY reactor reactor/
-COPY terminal terminal/
+COPY reactor reactor
+COPY terminal terminal
 COPY cabal.config elm.cabal LICENSE ./
 
 # Build statically linked elm binary


### PR DESCRIPTION
Sorry, missed that in previous PR (this has no functional impact, it's just cleaner because there was a slash for 3 directories, but not the 4th one, which was unintentional but looked like it was).