### PR TITLE
Replace uglifyjs with terser

### DIFF
--- a/hints/optimize.md
+++ b/hints/optimize.md
@@ -15,20 +15,18 @@ Okay, but how do we get those numbers?
 
 Step one is to compile with the `--optimize` flag. This does things like shortening record field names and unboxing values.
 
-Step two is to call `uglifyjs` with a bunch of special flags. The flags unlock optimizations that are unreliable in normal JS code, but because Elm does not have side-effects, they work fine for us!
+Step two is to call `terser` with a bunch of special flags. The flags unlock optimizations that are unreliable in normal JS code, but because Elm does not have side-effects, they work fine for us!
 
 Putting those together, here is how I would optimize `src/Main.elm` with two terminal commands:
 
 ```bash
 elm make src/Main.elm --optimize --output=elm.js
-uglifyjs elm.js --compress "pure_funcs=[F2,F3,F4,F5,F6,F7,F8,F9,A2,A3,A4,A5,A6,A7,A8,A9],pure_getters,keep_fargs=false,unsafe_comps,unsafe" | uglifyjs --mangle --output=elm.min.js
+terser elm.js --compress "pure_funcs=[F2,F3,F4,F5,F6,F7,F8,F9,A2,A3,A4,A5,A6,A7,A8,A9],pure_getters,keep_fargs=false,unsafe_comps,unsafe" --mangle --output=elm.min.js
 ```
 
 After this you will have an `elm.js` and a significantly smaller `elm.min.js` file!
 
-**Note 1:** `uglifyjs` is called twice there. First to `--compress` and second to `--mangle`. This is necessary! Otherwise `uglifyjs` will ignore our `pure_funcs` flag.
-
-**Note 2:** If the `uglifyjs` command is not available in your terminal, you can run the command `npm install uglify-js --global` to download it. You probably already have `npm` from getting `elm repl` working, but if not, it is bundled with [nodejs](https://nodejs.org/).
+**Note:** If the `terser` command is not available in your terminal, you can run the command `npm install terser --global` to download it. You probably already have `npm` from getting `elm repl` working, but if not, it is bundled with [nodejs](https://nodejs.org/).
 
 ## Scripts
 
@@ -46,7 +44,7 @@ min="elm.min.js"
 
 elm make --optimize --output=$js $@
 
-uglifyjs $js --compress "pure_funcs=[F2,F3,F4,F5,F6,F7,F8,F9,A2,A3,A4,A5,A6,A7,A8,A9],pure_getters,keep_fargs=false,unsafe_comps,unsafe" | uglifyjs --mangle --output=$min
+terser $js --compress "pure_funcs=[F2,F3,F4,F5,F6,F7,F8,F9,A2,A3,A4,A5,A6,A7,A8,A9],pure_getters,keep_fargs=false,unsafe_comps,unsafe" --mangle --output=$min
 
 echo "Initial size: $(cat $js | wc -c) bytes  ($js)"
 echo "Minified size:$(cat $min | wc -c) bytes  ($min)"
@@ -55,5 +53,5 @@ echo "Gzipped size: $(cat $min | gzip -c | wc -c) bytes"
 
 It also prints out all the asset sizes for you! Your server should be configured to gzip the assets it sends, so the last line is telling you how many bytes would _actually_ get sent to the user.
 
-Again, the important commands are `elm` and `uglifyjs` which work on any platform, so it should not be too tough to do something similar on Windows.
+Again, the important commands are `elm` and `terser` which work on any platform, so it should not be too tough to do something similar on Windows.
 


### PR DESCRIPTION
[terser](https://github.com/terser/terser) does not require two passes. I tried out running the `--compress` and `--mangle` passes separately, but running one pass with `--compress --mange` yields the exact same byte count (just as it should be). (uglifyjs, even in the current version 3.8.0, still requires two passes.)

The compression is very close to uglifyjs. uglifyjs takes a 691.340 bytes `elm.js` to 147.094 bytes, while terser yields 149.607 bytes.

The reason I tried out terser was that uglifyjs does not handle modern JavaScript (newer than ES5), which lead to an [issue in elm-pages](https://github.com/dillonkearns/elm-pages/issues/83#issuecomment-599667607). Terser does, is nicely documented, and easily replaces uglifyjs.

Supporting modern JS is not really relevant here right now, since the Elm compiler outputs ES5. But that terser only requires one pass makes explaining it easier.