### PR TITLE
Add viewport meta tag to HTML page builder

### DIFF
--- a/terminal/src/Develop/Generate/Help.hs
+++ b/terminal/src/Develop/Generate/Help.hs
@@ -26,6 +26,7 @@ makePageHtml moduleName maybeFlags =
 <html>
 <head>
   <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link type="text/css" rel="stylesheet" href="/_elm/styles.css">
   <script src="/_elm/elm.js"></script>
 </head>


### PR DESCRIPTION
Add a viewport meta tag when generating an HTML page directly, 
so that iPhones don't try and zoom out


**Quick Summary:** 

An old issue https://github.com/elm-lang/elm-make/issues/160


## SSCCE

```elm

```

- **Elm:** 0.19.1
- **Browser:** Safari - iPhone 7
- **Operating System:** 13.4.1



