### PR TITLE
Fix pull request expectations not getting posted

### DIFF
--- a/.github/workflows/set-pull-expectations.yml
+++ b/.github/workflows/set-pull-expectations.yml
@@ -1,21 +1,20 @@
 name: Set Pull Expectations
-on:
-  pull_request:
-    types: [opened]
+on: pull_request
+
 jobs:
   comment-on-pull:
     name: Comment On Pull
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github@v1.0.0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Comment PR
+        uses: thollander/actions-comment-pull-request@master
         with:
-          args: |
-            comment "Thanks for suggesting these code changes. To set expectations:
+          message:
+            "Thanks for suggesting these code changes. To set expectations:
 
             - Pull requests are reviewed in [batches](https://github.com/elm/expectations/blob/master/batching.md), so it can take some time to get a response.
             - Smaller pull requests are easier to review. To fix nine typos, nine specific issues will always go faster than one big one. Learn why [here](https://github.com/elm/expectations/blob/master/small-pull-requests.md).
             - Reviewers may not know as much as you about certain situations, so add links to supporting evidence for important claims, especially regarding standards for CSS, HTTP, URI, etc.
 
             Finally, please be patient with the core team. They are trying their best with limited resources."
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This should hopefully fix the comment not showing up on pull requests.
It needs testing.

That being said, I would like you to consider not doing it like this, but using githubs contributions feature, it quiet a bit better to me. 

https://help.github.com/en/github/building-a-strong-community/setting-guidelines-for-repository-contributors