### PR TITLE
Clarify BSD-3 is recommended license for packages.

### DIFF
--- a/docs/elm.json/package.md
+++ b/docs/elm.json/package.md
@@ -49,7 +49,7 @@ A short summary that will appear on [`package.elm-lang.org`](https://package.elm
 
 ## `"license"`
 
-An OSI approved SPDX code like `"BSD-3-Clause"` or `"MIT"`. These are the two most common licenses in the Elm ecosystem, but you can see the full list of options [here](https://spdx.org/licenses/).
+An OSI approved SPDX code like `"BSD-3-Clause"` or `"MIT"`. These are the two most common licenses in the Elm ecosystem, and BSD-3-Clause is a good default. But you can see the full list of options [here](https://spdx.org/licenses/).
 
 <br>
 


### PR DESCRIPTION
Context: I used to link to the "Preparing for Publication" section in the `elm-package` repo that recommended BSD-3 for package licenses.

> The recommended `license` is BSD3, but of course, you can use whatever license you want.

[It was removed](https://github.com/elm-lang/elm-package/commit/2076638d812d9dea641e6e695951495f523bb98f#diff-04c6e90faac2675aa89e2176d2eec7d8) when the `elm-publish` functionality was moved to the core repo. This change will allow me to point to a definitive source that says that BSD-3 is the recommended default in the Elm ecosystem.

See https://github.com/dillonkearns/idiomatic-elm-package-guide/issues/3