### PR TITLE
Remove claim about the Ruby language

### DIFF
--- a/hints/implicit-casts.md
+++ b/hints/implicit-casts.md
@@ -16,9 +16,6 @@ Languages that will add in implicit casts for addition include:
 
 These languages generally agree that an `Int` may be implicitly cast to a `Float` when necessary. So everyone is doing it, why not Elm?!
 
-> **Note:** Ruby does not follow the trend. They implicitly cast a `Float` to an `Int`, truncating all the decimal points!
-
-
 ## Type Inference + Implicit Casts
 
 Elm comes from the ML-family of languages. Languages in the ML-family that **never** do implicit casts include:


### PR DESCRIPTION
**Quick Summary:**

Remove an insufficiently-supported assertion about the Ruby language.

## Additional Details

The page on [Implicit Casts](/elm/compiler/blob/c4a81fcde7efe9199c0037d1810c08b32ebb7d08/hints/implicit-casts.md) says;

> Many languages automatically convert from Int to Float when they think it is necessary. This conversion is often called an implicit cast. Languages that will add in implicit casts for addition include...Ruby...These languages generally agree that an Int may be implicitly cast to a Float when necessary.

> Note: Ruby does not follow the trend. They implicitly cast a Float to an Int, truncating all the decimal points!

Since Ruby is mentioned as an exception, I assume the author had an example in mind.

I haven't been able to think of one. Vaguely close is the fact that `5 / 6` produces integer `0` with no implicit cast, such as to Float. (This is true also in [Java](http://stackoverflow.com/questions/4685450/int-division-why-is-the-result-of-1-3-0) and perhaps many other languages, but not in [JavaScript](http://nickthecoder.wordpress.com/2013/02/11/integer-division-in-javascript/) or [PHP](http://stackoverflow.com/questions/12832557/divide-integer-and-get-integer-value).)

Is this what the author had in mind?

So the assertion that "[T]hey implicitly cast a Float to an Int, truncating all the decimal points" is untrue, because there is no cast. (Two Ints result in an Int.)

BTW, regarding addition, the results of `5 + 6.1` and `5.1 + 6` are both Float (for example). (See the Ruby documentation for [Integer#+](http://docs.ruby-lang.org/en/2.7.0/Integer.html#method-i-2B) and [Float#+](http://docs.ruby-lang.org/en/2.7.0/Float.html#method-i-2B).)