### PR TITLE
Index differently into builtins vs custom types (Wasm)

### DIFF
--- a/compiler/src/AST/Optimized.hs
+++ b/compiler/src/AST/Optimized.hs
@@ -91,7 +91,8 @@ data Destructor =
 
 
 data Path
-  = Index Index.ZeroBased Path
+  = IndexBuiltin Index.ZeroBased Path
+  | IndexCustom Index.ZeroBased Path
   | Field Name Path
   | Unbox Path
   | Root Name
@@ -333,18 +334,20 @@ instance Binary Destructor where
 instance Binary Path where
   put destructor =
     case destructor of
-      Index a b -> putWord8 0 >> put a >> put b
-      Field a b -> putWord8 1 >> put a >> put b
-      Unbox a   -> putWord8 2 >> put a
-      Root a    -> putWord8 3 >> put a
+      IndexBuiltin a b -> putWord8 0 >> put a >> put b
+      IndexCustom a b -> putWord8 1 >> put a >> put b
+      Field a b -> putWord8 2 >> put a >> put b
+      Unbox a   -> putWord8 3 >> put a
+      Root a    -> putWord8 4 >> put a
 
   get =
     do  word <- getWord8
         case word of
-          0 -> liftM2 Index get get
-          1 -> liftM2 Field get get
-          2 -> liftM  Unbox get
-          3 -> liftM  Root get
+          0 -> liftM2 IndexBuiltin get get
+          1 -> liftM2 IndexCustom get get
+          2 -> liftM2 Field get get
+          3 -> liftM  Unbox get
+          4 -> liftM  Root get
           _ -> fail "problem getting Opt.Path binary"
 
 

--- a/compiler/src/Generate/JavaScript/Expression.hs
+++ b/compiler/src/Generate/JavaScript/Expression.hs
@@ -737,7 +737,10 @@ generateTailDef mode name argNames body =
 generatePath :: Mode.Mode -> Opt.Path -> JS.Expr
 generatePath mode path =
   case path of
-    Opt.Index index subPath ->
+    Opt.IndexBuiltin index subPath ->
+      JS.Access (generatePath mode subPath) (JsName.fromIndex index)
+
+    Opt.IndexCustom index subPath ->
       JS.Access (generatePath mode subPath) (JsName.fromIndex index)
 
     Opt.Root name ->
@@ -1015,7 +1018,10 @@ generateCaseTest mode root path exampleTest =
 pathToJsExpr :: Mode.Mode -> Name.Name -> DT.Path -> JS.Expr
 pathToJsExpr mode root path =
   case path of
-    DT.Index index subPath ->
+    DT.IndexBuiltin index subPath ->
+      JS.Access (pathToJsExpr mode root subPath) (JsName.fromIndex index)
+
+    DT.IndexCustom index subPath ->
       JS.Access (pathToJsExpr mode root subPath) (JsName.fromIndex index)
 
     DT.Unbox subPath ->

--- a/compiler/src/Optimize/Expression.hs
+++ b/compiler/src/Optimize/Expression.hs
@@ -270,16 +270,16 @@ destructHelp path (A.At region pattern) revDs =
     Can.PTuple a b (Just c) ->
       case path of
         Opt.Root _ ->
-          destructHelp (Opt.Index Index.third path) c =<<
-            destructHelp (Opt.Index Index.second path) b =<<
-              destructHelp (Opt.Index Index.first path) a revDs
+          destructHelp (Opt.IndexBuiltin Index.third path) c =<<
+            destructHelp (Opt.IndexBuiltin Index.second path) b =<<
+              destructHelp (Opt.IndexBuiltin Index.first path) a revDs
 
         _ ->
           do  name <- Names.generate
               let newRoot = Opt.Root name
-              destructHelp (Opt.Index Index.third newRoot) c =<<
-                destructHelp (Opt.Index Index.second newRoot) b =<<
-                  destructHelp (Opt.Index Index.first newRoot) a (Opt.Destructor name path : revDs)
+              destructHelp (Opt.IndexBuiltin Index.third newRoot) c =<<
+                destructHelp (Opt.IndexBuiltin Index.second newRoot) b =<<
+                  destructHelp (Opt.IndexBuiltin Index.first newRoot) a (Opt.Destructor name path : revDs)
 
     Can.PList [] ->
       pure revDs
@@ -306,9 +306,9 @@ destructHelp path (A.At region pattern) revDs =
       case args of
         [Can.PatternCtorArg _ _ arg] ->
           case opts of
-            Can.Normal -> destructHelp (Opt.Index Index.first path) arg revDs
+            Can.Normal -> destructHelp (Opt.IndexCustom Index.first path) arg revDs
             Can.Unbox  -> destructHelp (Opt.Unbox path) arg revDs
-            Can.Enum   -> destructHelp (Opt.Index Index.first path) arg revDs
+            Can.Enum   -> destructHelp (Opt.IndexCustom Index.first path) arg revDs
 
         _ ->
           case path of
@@ -324,19 +324,19 @@ destructTwo :: Opt.Path -> Can.Pattern -> Can.Pattern -> [Opt.Destructor] -> Nam
 destructTwo path a b revDs =
   case path of
     Opt.Root _ ->
-      destructHelp (Opt.Index Index.second path) b =<<
-        destructHelp (Opt.Index Index.first path) a revDs
+      destructHelp (Opt.IndexBuiltin Index.second path) b =<<
+        destructHelp (Opt.IndexBuiltin Index.first path) a revDs
 
     _ ->
       do  name <- Names.generate
           let newRoot = Opt.Root name
-          destructHelp (Opt.Index Index.second newRoot) b =<<
-            destructHelp (Opt.Index Index.first newRoot) a (Opt.Destructor name path : revDs)
+          destructHelp (Opt.IndexBuiltin Index.second newRoot) b =<<
+            destructHelp (Opt.IndexBuiltin Index.first newRoot) a (Opt.Destructor name path : revDs)
 
 
 destructCtorArg :: Opt.Path -> [Opt.Destructor] -> Can.PatternCtorArg -> Names.Tracker [Opt.Destructor]
 destructCtorArg path revDs (Can.PatternCtorArg index _ arg) =
-  destructHelp (Opt.Index index path) arg revDs
+  destructHelp (Opt.IndexCustom index path) arg revDs
 
 
 

--- a/compiler/src/Optimize/Port.hs
+++ b/compiler/src/Optimize/Port.hs
@@ -107,7 +107,7 @@ encodeTuple :: Can.Type -> Can.Type -> Maybe Can.Type -> Names.Tracker Opt.Expr
 encodeTuple a b maybeC =
   let
     let_ arg index body =
-      Opt.Destruct (Opt.Destructor arg (Opt.Index index (Opt.Root Name.dollar))) body
+      Opt.Destruct (Opt.Destructor arg (Opt.IndexBuiltin index (Opt.Root Name.dollar))) body
 
     encodeArg arg tipe =
       do  encoder <- toEncoder tipe


### PR DESCRIPTION
As discussed yesterday with @evancz. Thanks for the help!

This change has no effect on the JavaScript target but would help to
minimise conflicts with the Wasm fork (https://github.com/brian-carroll/elm-compiler)
That version uses a different structure for custom ADTs than for Cons and Tuple.

Background details:

All of the Wasm structures have basic type information squeezed into
a 4-bit enum in the value header. (Int, Float, String, Char, Cons,
Tuple2, Tuple3, Custom, Record, Closure, & some runtime structures).
That's a lot of useful info in the header without reading more bytes.

Custom types also need an additional 32-bit constructor ID but
for Cons and Tuples, the header tag is enough.
That means the first parameter for Custom ends up at a different
address offset within the structure, so code gen is different.
