### PR TITLE
Add Bool type to WebGL shader interface

### DIFF
--- a/compiler/src/AST/Utils/Shader.hs
+++ b/compiler/src/AST/Utils/Shader.hs
@@ -42,6 +42,7 @@ data Types =
 data Type
   = Int
   | Float
+  | Bool
   | V2
   | V3
   | V4

--- a/compiler/src/Parse/Shader.hs
+++ b/compiler/src/Parse/Shader.hs
@@ -174,6 +174,7 @@ extractInputs decl =
                 GLS.Mat4 -> [(qual, Shader.M4, name)]
                 GLS.Int -> [(qual, Shader.Int, name)]
                 GLS.Float -> [(qual, Shader.Float, name)]
+                GLS.Bool -> [(qual, Shader.Bool, name)]
                 GLS.Sampler2D -> [(qual, Shader.Texture, name)]
                 _ -> []
     _ -> []

--- a/compiler/src/Type/Constrain/Expression.hs
+++ b/compiler/src/Type/Constrain/Expression.hs
@@ -501,6 +501,7 @@ glToType glType =
     Shader.M4 -> Type.mat4
     Shader.Int -> Type.int
     Shader.Float -> Type.float
+    Shader.Bool -> Type.bool
     Shader.Texture -> Type.texture
 
 


### PR DESCRIPTION
**Quick Summary:**  Add Bool type to WebGL shader interface in order to fix the silent failure when compiling with `--optimize`

Fixes https://github.com/elm/compiler/issues/1970

There are other types that are not yet supported, but this is the most surprising one that you might run up against. Maybe a follow up fix would be to not fail silently but have a compile error with an explanation that it's just not implemented yet.

## SSCCE

(Copied from #1970)

```elm
module Main exposing (main)

import Html exposing (Html)
import Html.Attributes exposing (height, style, width)
import Math.Matrix4 as Mat4 exposing (Mat4)
import Math.Vector3 as Vec3 exposing (Vec3, vec3)
import WebGL exposing (Mesh, Shader)


main : Html msg
main =
    WebGL.toHtml
        [ width 400, height 400, style "display" "block" ]
        [ WebGL.entity
            vertexShader
            fragmentShader
            mesh
            { perspective = perspective
            , noColor = True
            }
        ]


perspective : Mat4
perspective =
    Mat4.mul
        (Mat4.makePerspective 45 1 0.01 100)
        (Mat4.makeLookAt (vec3 0 0 1) (vec3 0 0 0) (vec3 0 1 0))



-- Mesh


type alias Vertex =
    { position : Vec3
    , color : Vec3
    }


mesh : Mesh Vertex
mesh =
    WebGL.triangles
        [ ( Vertex (vec3 0 0 0) (vec3 1 0 0)
          , Vertex (vec3 1 1 0) (vec3 0 1 0)
          , Vertex (vec3 1 -1 0) (vec3 0 0 1)
          )
        ]


type alias Uniforms =
    { perspective : Mat4
    , noColor : Bool
    }


vertexShader : Shader Vertex Uniforms { vcolor : Vec3 }
vertexShader =
    [glsl|
        attribute vec3 position;
        attribute vec3 color;
        uniform mat4 perspective;
        uniform bool noColor;
        varying vec3 vcolor;
        void main () {
            gl_Position = perspective * vec4(position, 1.0);
            vcolor = vec3(noColor ? 0.0 : color.x, noColor ? 0.0 : color.y, noColor ? 0.0 : color.z);
        }
    |]


fragmentShader : Shader {} Uniforms { vcolor : Vec3 }
fragmentShader =
    [glsl|
        precision mediump float;
        varying vec3 vcolor;
        void main () {
            gl_FragColor = vec4(vcolor, 1.0);
        }
    |]
```
