### PR TITLE
Personalize MISSING EXPRESSION message

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -6,7 +6,7 @@ possible.
 
 ## Licensing
 
-You need to sign the [contributor agreement](ContributorAgreement.pdf)
+You need to sign the [contributor agreement](../ContributorAgreement.pdf)
 and send it to <info@elm-lang.org> before opening your pull request.
 
 ## Style Guide

--- a/compiler/src/Reporting/Error/Syntax.hs
+++ b/compiler/src/Reporting/Error/Syntax.hs
@@ -2591,7 +2591,7 @@ toExprReport source context expr startRow startCol =
                   ,"give","a","more","specific","hint!"
                   ]
               , D.toSimpleNote $
-                  "This can also happen if run into reserved words like `let` or `as` unexpectedly.\
+                  "This can also happen if I run into reserved words like `let` or `as` unexpectedly.\
                   \ Or if I run into operators in unexpected spots. Point is, there are a\
                   \ couple ways I can get confused and give sort of weird advice!"
               ]


### PR DESCRIPTION
**Quick Summary:** 
I encountered this error message when playing around in `elm repl`. I had to re-read the sentence a couple times to make sure I understood what the compiler was telling me. I hope this small change makes the message just a little easier to understand 😄 

I also updated the link to the ContributorAgreement as I encountered a 404 when I decided to submit this change. Let me know if you'd like that to be in a separate pull request 🙂 
