### PR TITLE
fix: add Accept-Encoding header to download request in npm installer

### DIFF
--- a/installers/npm/download.js
+++ b/installers/npm/download.js
@@ -45,7 +45,12 @@ module.exports = function(callback)
 	});
 
 	// put it all together
-	request(url).on('error', reportDownloadFailure).pipe(gunzip).pipe(write);
+	var options = {
+		url: url,
+		headers: { 'Accept-Encoding': 'gzip' }
+	};
+
+	request(options).on('error', reportDownloadFailure).pipe(gunzip).pipe(write);
 }
 
 


### PR DESCRIPTION
**Quick Summary:**
* When using the npm package and installer inside of a Alpine Linux container, an error was reported:
  * `Error: incorrect header check`
* Adding the `Acccept-Encoding` header to the download requests resolves the issue.
