### PR TITLE
Allow M1 users to continue to install elm via our npm package

### DIFF
--- a/installers/npm/download.js
+++ b/installers/npm/download.js
@@ -17,7 +17,7 @@ module.exports = function(callback)
 	// figure out URL of binary
 	var version = package.version.replace(/^(\d+\.\d+\.\d+).*$/, '$1'); // turn '1.2.3-alpha' into '1.2.3'
 	var os = { 'darwin': 'mac', 'win32': 'windows', 'linux': 'linux' }[process.platform];
-	var arch = { 'x64': '64-bit', 'ia32': '32-bit' }[process.arch];
+	var arch = { 'x64': '64-bit', 'arm64': '64-bit', 'ia32': '32-bit' }[process.arch];
 	var url = 'https://github.com/elm/compiler/releases/download/' + version + '/binary-for-' + os + '-' + arch + '.gz';
 
 	reportDownload(version, url);


### PR DESCRIPTION
**Quick Summary:**

Allow M1 users to continue to install via npm and use the `x64:64-bit` binary (via rosetta) until we get a native build.

## Additional Details

I would like to continue to allow people with M1 macs to install and use Elm through the npm package, and I think this is a decent stop-gap until we can get a native build. Right now the install fails trying to install a url that does not exist (because the darwin/arm64 combo is not covered), this falls back to the `x64:64-bit` binary download and lets them use Rosetta.

This isn't a problem anywhere else, because the other methods of installation are direct binary downloads, so it asks the user to either install Rosetta or uses Rosetta directly, we just need to make sure we allow them to still get the binary.

Thanks!