### PR TITLE
Update hint - errors when importing packages

### DIFF
--- a/compiler/src/Reporting/Error/Import.hs
+++ b/compiler/src/Reporting/Error/Import.hs
@@ -66,7 +66,8 @@ toReport source (Error region name unimportedModules problem) =
                   Nothing ->
                     D.toSimpleHint $
                       "If it is not a typo, check the \"dependencies\" and \"source-directories\"\
-                      \ of your elm.json to make sure all the packages you need are listed there!"
+                      \ of your elm.json to make sure all the packages you need are listed there!\
+                      \ (e.g. You can install packages like this: `elm install elm/http`)"
 
                   Just dependency ->
                     D.toFancyHint


### PR DESCRIPTION
**Quick Summary:** 

* I was trying to import a package and I received this message here:

![image](https://user-images.githubusercontent.com/15097447/114329842-bedb5b80-9b83-11eb-8fe5-8b0b5d158b5b.png)

* What does this mean? The message is helpful but does not pose the _solution_ required: how to import or install the library? 
* This PR goes a small way towards alleviating that problem. I feel that this is in keeping with the goals of the elm compiler: clear error messages, and clear solutions to the problems. For the advanced users, the solution may be obvious -- not so for others.
* **Note:** this might not be the best solution. "You can install packages like this: `elm install elm/http`". we are hard coding the solution: `elm install elm/http`. perhaps the compiler should be smart enough to suggest the correct module to install?  
* As always, these PRs are merely ideas for consideration. If they do not align with the goals of the library etc. feel free to close without compunction.

**Terms of contribution**

- I am in agreement with the terms of [contribution](https://github.com/elm/compiler/blob/master/ContributorAgreement.pdf) - the form has been completed and sent to the email address.

Ben