### PR TITLE
Expand npm installer to include ARM64 Linux

### DIFF
--- a/installers/npm/download.js
+++ b/installers/npm/download.js
@@ -21,7 +21,8 @@ module.exports = function(callback)
 		darwin_x64: 'mac-64-bit',
 		darwin_arm64: 'mac-64-bit',
 		win32_x64: 'windows-64-bit',
-		linux_x64: 'linux-64-bit'
+		linux_x64: 'linux-64-bit',
+		linux_arm64: 'linux-64-bit'
 	}[process.platform + '_' + process.arch];
 
 	verifyPlatform(version, platform);


### PR DESCRIPTION
A quickfix to #2232 (see comments there), though it may be re-written better or removed entirely (the only main architecture/OS combo this seems to leave out now is ARM Windows).

Or maybe we want to un-do https://github.com/elm/compiler/commit/759bf04a298a357018d13c85cbb315549893c26d in its entirety?

(Note that this lets Apple Silicon users with Elm in docker containers use the npm installer)