### PR TITLE
Fix in-browser compiler error display

### DIFF
--- a/reactor/src/Errors.elm
+++ b/reactor/src/Errors.elm
@@ -57,6 +57,9 @@ viewError error =
         , style "white-space" "pre-wrap"
         , style "background-color" "black"
         , style "padding" "2em"
+        , style "box-sizing" "border-box"
+        , style "width" "100%"
+        , style "overflow" "scroll"
         ]
         (viewErrorHelp error)
     ]


### PR DESCRIPTION
**Quick Summary:** Fix: Error display breaks on long text - the left and right part of the source code is clipped.


## SSCCE

```elm
string< = "..............................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................."
```

It looks like this and I can only scroll to the right:
<img width="1728" alt="image" src="https://user-images.githubusercontent.com/7485959/158644209-f86c574a-86c9-4bf5-b8fe-9c20ce2c5a42.png">


- **Elm:** 0.19.1
- **Browser:** Version 99.0.4844.51 (Official Build) (arm64)
- **Operating System:** OSX 12.0.1 (21A559)
