### PR TITLE
Fix typo of installed bin PATH with npm

### DIFF
--- a/installers/npm/README.md
+++ b/installers/npm/README.md
@@ -37,7 +37,7 @@ The following command should download the latest Elm 0.19.1 binary:
 npm install elm@latest-0.19.1
 ```
 
-You should be able to run `./node_modules/bin/elm --version` within your project and see `0.19.1`. Now you can compile with `./node_modules/bin/elm make src/Main.elm` and not disrupt other packages.
+You should be able to run `./node_modules/.bin/elm --version` within your project and see `0.19.1`. Now you can compile with `./node_modules/.bin/elm make src/Main.elm` and not disrupt other packages.
 
 Use `npm install elm@latest-0.19.0` or `npm install elm@latest-0.18.0` for earlier versions.
 


### PR DESCRIPTION
**Quick Summary:** In documents around installation with npm,  the installed bin path having a typo.

## SSCCE

```console
$ node -v
v18.12.1

$ npm --version
8.19.2

$ npm install elm@latest-0.19.1
...
added 48 packages, and audited 49 packages in 3s
...

$ ./node_modules/bin/elm --version
bash: ./node_modules/bin/elm: No such file or directory

$ ./node_modules/.bin/elm --version
0.19.1
```

- **Elm:** 0.19.1
- **Node.js:** 19.3.0, 18.12.1, 14.7.0
- **npm:** 9.2.0, 8.19.2
- **Operating System:** `Linux 5.15.79.1-microsoft-standard-WSL2 #1 SMP Wed Nov 23 01:01:46 UTC 2022 x86_64 x86_64 x86_64 GNU/Linux`

## Additional Details

I found this issue in reading https://www.npmjs.com/package/elm.
