### PR TITLE
npm installer: Download elm package without deprecated libraries.

### DIFF
--- a/installers/npm/download.js
+++ b/installers/npm/download.js
@@ -1,7 +1,7 @@
 var fs = require('fs');
 var package = require('./package.json');
 var path = require('path');
-var request = require('request');
+var { https } = require('follow-redirects');
 var zlib = require('zlib');
 
 
@@ -53,7 +53,7 @@ module.exports = function(callback)
 	});
 
 	// put it all together
-	request(url).on('error', reportDownloadFailure).pipe(gunzip).pipe(write);
+	https.get(url, (res) => { res.pipe(gunzip).pipe(write); }).on('error', reportDownloadFailure);
 }
 
 

--- a/installers/npm/package.json
+++ b/installers/npm/package.json
@@ -35,8 +35,11 @@
     "install",
     "installer"
   ],
-  "bin": { "elm": "bin/elm" },
+  "bin": {
+    "elm": "bin/elm"
+  },
   "dependencies": {
-    "follow-redirects": "^1.15.2"
+    "follow-redirects": "^1.15.2",
+    "proxy-agent": "^6.3.0"
   }
 }

--- a/installers/npm/package.json
+++ b/installers/npm/package.json
@@ -37,6 +37,6 @@
   ],
   "bin": { "elm": "bin/elm" },
   "dependencies": {
-    "request": "^2.88.0"
+    "follow-redirects": "^1.15.2"
   }
 }

--- a/installers/npm/package.json
+++ b/installers/npm/package.json
@@ -19,7 +19,7 @@
     "node": ">=7.0.0"
   },
   "scripts": {
-    "install": "node install.js"
+    "postinstall": "node install.js"
   },
   "files": [
     "install.js",
@@ -40,6 +40,6 @@
   },
   "dependencies": {
     "follow-redirects": "^1.15.2",
-    "proxy-agent": "^6.3.0"
+    "proxy-from-env": "^1.1.0"
   }
 }


### PR DESCRIPTION
**Quick Summary:**
[request](https://www.npmjs.com/package/request) is deprecated, and vulnerabilities have been reported in its dependency libraries.
I replaced download feature using following libraries:
- [follow-redirects](https://www.npmjs.com/package/follow-redirects)
- [proxy-from-env](https://www.npmjs.com/package/proxy-from-env)

Ref: https://github.com/elm/compiler/commit/41ec49ed921a2409afda483eb9e29197e262fe27

**Thought:** 
[axios](https://www.npmjs.com/package/axios) also depends on the same libraries (follow-redirects, proxy-from-env), but there is no need to use Promise-based features.
To improve maintainability, I believe that we should adopt libraries with simple enough functions to meet our needs,rather than relying on a library with many additional functions.