### PR TITLE
Align indentation where cabal check warns about it

### DIFF
--- a/elm.cabal
+++ b/elm.cabal
@@ -35,9 +35,9 @@ Flag dev {
 
 
 Executable elm
-        ghc-options: -O2 -rtsopts -threaded "-with-rtsopts=-N -qg -A128m"
-        -- add -eventlog for (elm make src/Main.elm +RTS -l; threadscope elm.eventlog)
-        -- https://www.oreilly.com/library/view/parallel-and-concurrent/9781449335939/
+    ghc-options: -O2 -rtsopts -threaded "-with-rtsopts=-N -qg -A128m"
+    -- add -eventlog for (elm make src/Main.elm +RTS -l; threadscope elm.eventlog)
+    -- https://www.oreilly.com/library/view/parallel-and-concurrent/9781449335939/
 
     Hs-Source-Dirs:
         compiler/src


### PR DESCRIPTION
Fixes the warning about inconsistent indentation in the package.

```
$ cabal check
...
Warning: elm.cabal:42:5: Inconsistent indentation. Indentation jumps at lines
42
...
```

Found when adding `elm-compiler` as an [Updo example](https://github.com/up-do). I noticed the warning there:

```
$ cabal build all --enable-tests --enable-benchmarks
Warning: Unknown/unsupported 'ghc' version detected (Cabal 3.11.0.0 supports
'ghc' version < 9.8): /home/philderbeast/.ghcup/bin/ghc is version 9.8.1
Resolving dependencies...
Build profile: -w ghc-9.8.1 -O1
In order, the following will be built (use -v for more details):
 - elm-0.19.1 (exe:elm) (first run)
Warning: elm.cabal:42:5: Inconsistent indentation. Indentation jumps at lines
42
Configuring executable 'elm' for elm-0.19.1...
...
```

