### PR TITLE
Update Elm Slack Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,4 +19,4 @@ For multiple versions, previous versions, and uninstallation, see the instructio
 
 If you are stuck, ask around on [the Elm slack channel][slack]. Folks are friendly and happy to help with questions!
 
-[slack]: http://elmlang.herokuapp.com/
+[slack]: https://elm-lang.org/community/slack


### PR DESCRIPTION
**Quick Summary:** 

The Slack Link on the README.md file doesn't work, and just goes to a Heroku 404 page, I've changed it for the slack page which is provided in https://elm-lang.org/community/slack


## SSCCE

- **Elm:** 0.19.1
- **Browser:** Safari
- **Operating System:** MacOS 14.1