### PR TITLE
Force using a version of tls older than 2

### DIFF
--- a/elm.cabal
+++ b/elm.cabal
@@ -229,6 +229,7 @@ Executable elm
         snap-server,
         template-haskell,
         time,
+        tls < 2,
         unordered-containers,
         utf8-string,
         vector,


### PR DESCRIPTION
## Problem

On a fresh git clone (commit 2f6dd29), fresh install of Haskell via GHCup (GHCup 0.1.22.0, cabal 3.10.3.1, GHC 9.4.8), on Windows 10, I get the following error:

```bash
~/src/elm-compiler $ cabal build
[...]
[129 of 132] Compiling Develop.StaticFiles ( terminal\src\Develop\StaticFiles.hs, [...]\elm-compiler\dist-newstyle\build\x86_64-windows\ghc-9.4.8\elm-0.19.1\x\elm\build\elm\elm-tmp\Develop\StaticFiles.o )
-- PROBLEM LOADING PACKAGE LIST ------------------------------------------------

I need the list of published packages to verify your dependencies, so I tried to
fetch:

    https://package.elm-lang.org/all-packages

But my HTTP library is giving me the following error message:

    InternalException (HandshakeFailed (Error_Protocol "peer does not support Extended Main Secret" HandshakeFailure))

Are you somewhere with a slow internet connection? Or no internet? Does the link
I am trying to fetch work in your browser? Maybe the site is down? Does your
internet connection have a firewall that blocks certain domains? It is usually
something like that!


terminal\src\Develop\StaticFiles.hs:91:3: error:
    * Exception when trying to run compile-time code:

--------------------------------------------------------
Error in Develop.StaticFiles.Build.buildReactorFrontEnd
Compile with `elm make` directly to figure it out faster
--------------------------------------------------------

CallStack (from HasCallStack):
  error, called at terminal/src\Develop\StaticFiles\Build.hs:68:15 in main:Develop.StaticFiles.Build
      Code: (bsToExp =<< runIO Build.buildReactorFrontEnd)
    * In the untyped splice:
        $(bsToExp =<< runIO Build.buildReactorFrontEnd)
   |
91 |   $(bsToExp =<< runIO Build.buildReactorFrontEnd)
   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Error: cabal-3.10.3.0.exe: Failed to build exe:elm from elm-0.19.1.
```

## Quick fix

Several sources suggest that this is due to the server of `https://package.elm-lang.org/all-packages` not being up to date on its TLS implementation. The suggested workaround is always to backport the `tls` package to a version < 2, i.e., before they dropped support for this kind of outdated server.

## Better fix

IMHO this should rather be solved on the server side, but as I may not be the only person around bumping into this issue, I open this PR with a fix that anybody can run in the meantime.