### PR TITLE
add occurs checks for all unifications

### DIFF
--- a/compiler/src/Type/Unify.hs
+++ b/compiler/src/Type/Unify.hs
@@ -166,15 +166,20 @@ fresh (Context _ (Descriptor _ rank1 _ _) _ (Descriptor _ rank2 _ _)) content =
 guardedUnify :: Variable -> Variable -> Unify ()
 guardedUnify left right =
   Unify $ \vars ok err ->
-    do  equivalent <- UF.equivalent left right
-        if equivalent
-          then ok vars ()
+    do  occursLeft <- Occurs.occurs left
+        occursRight <- Occurs.occurs right
+        if occursLeft || occursRight
+          then err vars ()
           else
-            do  leftDesc <- UF.get left
-                rightDesc <- UF.get right
-                case actuallyUnify (Context left leftDesc right rightDesc) of
-                  Unify k ->
-                    k vars ok err
+            equivalent <- UF.equivalent left right
+            if equivalent
+              then ok vars ()
+              else
+                do  leftDesc <- UF.get left
+                    rightDesc <- UF.get right
+                    case actuallyUnify (Context left leftDesc right rightDesc) of
+                      Unify k ->
+                        k vars ok err
 
 
 subUnify :: Variable -> Variable -> Unify ()


### PR DESCRIPTION
This fixes https://github.com/elm/compiler/issues/2241

Preliminary testing seems to indicate this isn't as bad of a slowdown as it may seem. For more details see https://github.com/Zokka-Dev/zokka-compiler/pull/20

This is meant as a reference PR for other people working on the Elm compiler.