### PR TITLE
Allow Spanish translation of the guide to use the REPL

### DIFF
--- a/worker/src/Endpoint/Repl.hs
+++ b/worker/src/Endpoint/Repl.hs
@@ -49,6 +49,7 @@ allowedOrigins :: [String]
 allowedOrigins =
   [ "https://guide.elm-lang.org"
   , "https://guide.elm-lang.jp"
+  , "https://agj.github.io"
   , "http://localhost:8007"
   ]
 


### PR DESCRIPTION
Adds a new "allowed origin" URL to the list used in the REPL service.

Thank you, Evan!