### PR TITLE
Fix off-by-one in source regions emitted to JSON and Debug.todo

### DIFF
--- a/compiler/src/Generate/JavaScript/Expression.hs
+++ b/compiler/src/Generate/JavaScript/Expression.hs
@@ -309,8 +309,8 @@ regionToJsExpr (A.Region start end) =
     ]
   where
     (===>) n v = (JsName.fromLocal n, v)
-    (sr, sc) = A.toRowCol start
-    (er, ec) = A.toRowCol end
+    (sr, sc) = A.toEditorRowCol start
+    (er, ec) = A.toEditorRowCol end
 
 
 

--- a/compiler/src/Reporting/Annotation.hs
+++ b/compiler/src/Reporting/Annotation.hs
@@ -9,6 +9,7 @@ module Reporting.Annotation
   , merge
   , at
   , toRowCol
+  , toEditorRowCol
   , toRow
   , toCol
   , toRegion
@@ -78,6 +79,17 @@ toRowCol :: Word64# -> (Int, Int)
 toRowCol pos =
   ( fromIntegral (toRow pos)
   , fromIntegral (toCol pos)
+  )
+
+
+-- Editor coordinates start at (1,1); the packed representation starts at (0,0).
+-- Anything that leaves the compiler for a human or a tool must go through this,
+-- not through toRowCol.
+{-# INLINE toEditorRowCol #-}
+toEditorRowCol :: Word64# -> (Int, Int)
+toEditorRowCol pos =
+  ( fromIntegral (toRow pos) + 1
+  , fromIntegral (toCol pos) + 1
   )
 
 

--- a/compiler/src/Reporting/Error.hs
+++ b/compiler/src/Reporting/Error.hs
@@ -200,6 +200,6 @@ encodeRegion (A.Region start end) =
     , "end"   ==> E.object [ "line" ==> E.int er, "column" ==> E.int ec ]
     ]
   where
-    (sr,sc) = A.toRowCol start
-    (er,ec) = A.toRowCol end
+    (sr,sc) = A.toEditorRowCol start
+    (er,ec) = A.toEditorRowCol end
 


### PR DESCRIPTION
Fixes #2358.

In 0.19.2 `Reporting.Annotation.Position` became a packed `Word64#`, and its own comment states the new contract:

```haskell
-- The initial value is (0,0) so conversion is needed to get
-- "editor coordinates" which start at (1,1)
```

`Reporting.Render.Code` performs that conversion (`show (row + 1)`), which is why the terminal error report is still correct. The two places that emit *machine-readable* coordinates call `A.toRowCol` raw and never convert:

- `Reporting.Error.encodeRegion` — used by `elm make --report=json`, which editors and `elm-language-server` consume
- `Generate.JavaScript.Expression.regionToJsExpr` — used for `Debug.todo` / `Debug.todoCase`

So every JSON diagnostic is one line up and one column left, and a `Debug.todo` on line 17 crashes with `` TODO in module `Main` on line 16 ``.

## The change

Add a `toEditorRowCol` helper next to `toRowCol` and use it at the two emit sites. `Reporting.Render.Code` uses `toRow` / `toCol` directly and already does its own conversion, so it is untouched.

Note: after this change `toRowCol` has **no remaining callers** — both of its consumers wanted editor coordinates. Making `toRowCol` itself 1-based would be a smaller diff; I kept a separately named function so the (0,0)-based accessor stays available and the conversion is explicit at the point of use. Happy to switch to whichever you prefer.

## Verification

Built with GHC 9.8.4 (`cabal build exe:elm`, so under the package's `-Wall -Werror`): 137/137 modules, links cleanly.

SSCCE from #2358 — `Debug.todo` on line 17, column 5; type error on line 6, columns 5–17:

| compiler | `Debug.todo` region | runtime message | `--report=json` region |
|---|---|---|---|
| 0.19.1 | `(17,5)–(17,15)` | `` on line 17 `` | `(6,5)–(6,17)` |
| 0.19.2 | `(16,4)–(16,14)` | `` on line 16 `` | `(5,4)–(5,16)` |
| **0.19.2 + this patch** | **`(17,5)–(17,15)`** | **`` on line 17 ``** | **`(6,5)–(6,17)`** |

The patched compiler matches 0.19.1 exactly.

Also checked:

- The human-readable report is unchanged — still `6|     "not an int"` with the caret correctly aligned, i.e. not double-incremented.
- On a real 548-module application, all 12 `Debug.todo` regions emitted into the bundle become identical to the 0.19.1 output (Δline = Δcolumn = 0 for every one), where before the patch every one was off by exactly `(-1, -1)`.
